### PR TITLE
Failure of constr. projection now correctly handled in visibPRM

### DIFF
--- a/include/hpp/core/visibility-prm-planner.hh
+++ b/include/hpp/core/visibility-prm-planner.hh
@@ -68,6 +68,7 @@ namespace hpp {
       /// projecting it on the tangent space of qFrom.
       ConfigurationPtr_t applyConstraints (const ConfigurationPtr_t qFrom, 
 					   const ConfigurationPtr_t qTo);
+      bool constrApply_; // True if applyConstraints has successed
     };
     /// \}
   } // namespace core


### PR DESCRIPTION
For a constrained problem, previous version of visib-PRM was using the projected sampled configuration even if he projection has failed.
This was leading to anormal 'jumps' of configurations when these wrongly projected configurations were present in the final path.