### PR TITLE
disambiguation of Eigen matrix initialization in 64 bits

### DIFF
--- a/include/hpp/core/weighed-distance.hh
+++ b/include/hpp/core/weighed-distance.hh
@@ -41,7 +41,7 @@ namespace hpp {
       virtual DistancePtr_t clone () const;
       /// Get weight of joint at given rank
       /// \param rank rank of the joint in robot joint vector
-      value_type getWeight( int rank ) const;
+      value_type getWeight( std::size_t rank ) const;
       /// Set weight of joint at given rank
       /// \param rank rank of the joint in robot joint vector
       void setWeight(unsigned int rank, value_type weight);

--- a/src/config-projector.cc
+++ b/src/config-projector.cc
@@ -88,14 +88,14 @@ namespace hpp {
       intervals_.clear ();
       nbLockedDofs_ = 0;
       std::pair < size_type, size_type > interval;
-      int latestIndex = 0;
+      std::size_t latestIndex = 0;
       size_type size;
       lockedJoints_.sort ();
       // temporarily add an element at the end of the list.
       lockedJoints_.push_back (LockedJoint::create (robot_));
       for (LockedJoints_t::const_iterator itLocked = lockedJoints_.begin ();
 	   itLocked != lockedJoints_.end (); ++itLocked) {
-	int index = (*itLocked)->rankInVelocity ();
+    std::size_t index = (*itLocked)->rankInVelocity ();
 	nbLockedDofs_ += (*itLocked)->numberDof ();
 	hppDout (info, "number locked dof " << (*itLocked)->numberDof ());
 	size = (index - latestIndex);
@@ -104,7 +104,7 @@ namespace hpp {
 	  interval.second = size;
 	  intervals_.push_back (interval);
 	}
-	latestIndex = index + (*itLocked)->numberDof ();
+    latestIndex = index + (*itLocked)->numberDof ();
       }
       // Remove temporary element.
       lockedJoints_.pop_back ();

--- a/src/continuous-collision-checking/dichotomy/body-pair-collision.hh
+++ b/src/continuous-collision-checking/dichotomy/body-pair-collision.hh
@@ -212,8 +212,8 @@ namespace hpp {
 	    Configuration_t q = (*path_) (t);
 	    // Compute position of joint a in frame of common ancestor
 	    model::Transform3f Ma, tmp;
-	    for (int i = indexCommonAncestor_ - 1; i >= 0; --i) {
-	      joints_ [(std::size_t)i]->computePosition (q, Ma, tmp);
+        for (int i = (int)indexCommonAncestor_ - 1; i >= 0; --i) {
+          joints_ [(std::size_t)i]->computePosition (q, Ma, tmp);
 	      Ma = tmp;
 	    }
 	    // Compute position of joint b in frame of common ancestor

--- a/src/equation.cc
+++ b/src/equation.cc
@@ -47,7 +47,7 @@ namespace hpp {
       comparison_ (comp), rhs_ (rhs)
     {
       if (comparison_->constantRightHandSide ())
-        rhs_ = vector_t (0);
+        rhs_ = vector_t ();
     }
   } // namespace core
 } // namespace hpp

--- a/src/nearest-neighbor/k-d-tree.cc
+++ b/src/nearest-neighbor/k-d-tree.cc
@@ -77,7 +77,7 @@ namespace hpp {
 	      itJoint != jointVector.end (); ++itJoint) {
 	   weights_.segment ((*itJoint)->rankInConfiguration (),
 			     (*itJoint)->configSize ()).setConstant
-	     (distance_->getWeight (i));
+         (distance_->getWeight (i));
 	   ++i;
 	 }
       this->findDeviceBounds();
@@ -239,7 +239,7 @@ namespace hpp {
 			      const ConnectedComponentPtr_t& connectedComponent,
                               value_type& minDistance) {
       // Test if the configuration is in the root box
-      for ( int i=0 ; i<dim_ ; i++ ) {
+      for ( std::size_t i=0 ; i<dim_ ; i++ ) {
 	if ( (*configuration)[i] < lowerBounds_[i] || (*configuration)[i]
 	     > upperBounds_[i] ) {
 	  std::ostringstream oss ("The Configuration isn't in the root box: \n"

--- a/src/nearest-neighbor/k-d-tree.hh
+++ b/src/nearest-neighbor/k-d-tree.hh
@@ -63,17 +63,17 @@ namespace hpp {
       }
     private:
       DevicePtr_t robot_;
-      int dim_;
+      std::size_t dim_;
 
       WeighedDistancePtr_t distance_;
       vector_t weights_;
       typedef std::map <ConnectedComponentPtr_t, Nodes_t> NodesMap_t;
       NodesMap_t nodesMap_;
-      unsigned int bucketSize_;
-      unsigned int bucket_;
+      std::size_t bucketSize_;
+      std::size_t bucket_;
 
       // number of the splited dimention
-      int splitDim_;
+      std::size_t splitDim_;
       vector_t upperBounds_;
       vector_t lowerBounds_;
 

--- a/src/path-optimization/gradient-based.cc
+++ b/src/path-optimization/gradient-based.cc
@@ -112,8 +112,7 @@ namespace hpp {
 
       GradientBased::GradientBased (const Problem& problem) :
 	PathOptimizer (problem), cost_ (), robot_ (problem.robot ()),
-	configSize_ (robot_->configSize ()), numberDofs_ (robot_->numberDof ()),
-	initial_ (0), end_ (0)
+    configSize_ (robot_->configSize ()), numberDofs_ (robot_->numberDof ())
       {
 	distance_ = HPP_DYNAMIC_PTR_CAST (WeighedDistance, problem.distance ());
 	if (!distance_) {

--- a/src/path-optimization/path-length.cc
+++ b/src/path-optimization/path-length.cc
@@ -184,7 +184,7 @@ namespace hpp {
 	  for (size_type k = 0; k <= j; ++k) {
 	    result.block (j*numberDofs_, k*numberDofs_,
 			  numberDofs_, numberDofs_) =
-	      ((value_type) (k+1)*(n-j-1))/n*inverseWeight;
+          (value_type) ((k+1)*(n-j-1))/((value_type)n)*inverseWeight;
 	    if (k != j) {
 	      result.block (k*numberDofs_, j*numberDofs_,
 			    numberDofs_, numberDofs_) =

--- a/src/weighed-distance.cc
+++ b/src/weighed-distance.cc
@@ -68,7 +68,7 @@ namespace hpp {
       return createCopy (weak_.lock ());
     }
 
-    value_type WeighedDistance::getWeight( int rank ) const
+    value_type WeighedDistance::getWeight( std::size_t rank ) const
     {
       return weights_[rank];
     }


### PR DESCRIPTION
Thes modifications are necessary to allow compilation of hpp-core in 64bits.
In this context,
using 0 as a parameter to a dynamic Eigen::Matrix constructor is ambigous since 0 can design
the dimension of the matrix, or the null pointer.
Also, default initilalisation of such objects consider a dimension of 0, therefore
calling the constructor explicitely is not necessary