### PR TITLE
Devel

### DIFF
--- a/include/hpp/core/roadmap.hh
+++ b/include/hpp/core/roadmap.hh
@@ -182,7 +182,7 @@ namespace hpp {
       void merge (const ConnectedComponentPtr_t& cc1,
 		  ConnectedComponents_t& ccs);
 
-      const DistancePtr_t& distance_;
+      const DistancePtr_t distance_;
       ConnectedComponents_t connectedComponents_;
       Nodes_t nodes_;
       Edges_t edges_;

--- a/src/nearest-neighbor/basic.hh
+++ b/src/nearest-neighbor/basic.hh
@@ -80,7 +80,7 @@ namespace hpp {
       }
 
     private:
-      const DistancePtr_t& distance_;
+      const DistancePtr_t distance_;
     }; // class Basic
     } // namespace nearestNeighbor
   } // namespace core

--- a/src/nearest-neighbor/basic.hh
+++ b/src/nearest-neighbor/basic.hh
@@ -53,7 +53,7 @@ namespace hpp {
 				connectedComponent,
 			       value_type& distance)
       {
-	NodePtr_t result;
+	NodePtr_t result = NULL;
 	distance = std::numeric_limits <value_type>::infinity ();
 	for (Nodes_t::const_iterator itNode =
 	       connectedComponent->nodes ().begin ();

--- a/src/parser/roadmap-factory.cc
+++ b/src/parser/roadmap-factory.cc
@@ -60,6 +60,7 @@ namespace hpp {
         p.addObjectFactory ("roadmap", RoadmapFactory::ArgumentParser::create);
         p.addObjectFactory ("joints", create <StringSequence>);
         p.addObjectFactory ("node", create <ConfigurationFactory>);
+        p.addObjectFactory ("path", create <ObjectFactory>);
         p.parseFile (fn);
         ObjectFactory* rf = 0;
         p.root ()->getChildOfType ("roadmap", rf);


### PR DESCRIPTION
* Add the default factory for tag "path" in the RoadmapFactory. …
  * This avoids the warning messages "I have no factory for tag path".

* Do not use reference on shared pointers. …
  * The shared pointer refered to might be deleted, without the underlying
  * object being deleted. This situation creates an invalid reference.

* Initialize pointer in nearestNeighbor::Basic …
  * This avoids the warning "may be used uninitialized" and make sure
  * assert () on the pointer actually make sense.