### PR TITLE
Devel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ SET(${PROJECT_NAME}_HEADERS
   include/hpp/core/connected-component.hh
   include/hpp/core/constraint.hh
   include/hpp/core/constraint-set.hh
+  include/hpp/core/container.hh
   include/hpp/core/continuous-collision-checking/dichotomy.hh
   include/hpp/core/continuous-collision-checking/progressive.hh
   include/hpp/core/diffusing-planner.hh

--- a/include/hpp/core/container.hh
+++ b/include/hpp/core/container.hh
@@ -1,0 +1,116 @@
+// Copyright (c) 2015, LAAS-CNRS
+// Authors: Joseph Mirabel (joseph.mirabel@laas.fr)
+//
+// This file is part of hpp-core.
+// hpp-core is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-core is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-core. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HPP_CORE_CONTAINER_HH
+# define HPP_CORE_CONTAINER_HH
+
+# include <map>
+# include <list>
+# include <boost/smart_ptr/shared_ptr.hpp>
+
+# include <hpp/core/config.hh>
+
+namespace hpp {
+  namespace core {
+    template < typename Element, typename Key = std::string>
+    class HPP_CORE_DLLAPI Container
+    {
+      public:
+        typedef std::map <Key, Element> ElementMap_t;
+        typedef typename ElementMap_t::iterator iterator;
+        typedef typename ElementMap_t::const_iterator const_iterator;
+        typedef Key Key_t;
+        typedef Element Element_t;
+
+        /// Add an element
+        void add (const Key& name, const Element& element)
+        {
+          map_[name] = element;
+        }
+
+        /// Return the element named name
+        bool has (const Key& name) const
+        {
+          return (map_.find (name) != map_.end ());
+        }
+
+        /// Return the element named name
+        const Element& get (const Key& name) const
+        {
+          typename ElementMap_t::const_iterator it = map_.find (name);
+          if (it == map_.end ()) throw std::runtime_error ("invalid key");
+          return it->second;
+        }
+
+        /// Return a list of all elements
+        /// \tparam ReturnType must have a push_back method.
+        template <typename ReturnType>
+        ReturnType getAllAs () const
+        {
+          ReturnType l;
+          for (typename ElementMap_t::const_iterator it = map_.begin ();
+              it != map_.end (); ++it)
+            l.push_back (it->second);
+          return l;
+        }
+
+        template <typename ReturnType>
+        ReturnType getKeys () const
+        {
+          ReturnType l;
+          for (typename ElementMap_t::const_iterator it = map_.begin ();
+              it != map_.end (); ++it)
+            l.push_back (it->first);
+          return l;
+        }
+
+        /// Return the underlying map.
+        const ElementMap_t& getAll () const
+        {
+          return map_;
+        }
+
+        /// Print object in a stream
+        std::ostream& print (std::ostream& os) const
+        {
+          for (typename ElementMap_t::const_iterator it = map_.begin ();
+              it != map_.end (); ++it) {
+            os << it->first << " : " << it->second << std::endl;
+          }
+          return os;
+        }
+
+        /// Print object in a stream
+        std::ostream& printPointer (std::ostream& os) const
+        {
+          for (typename ElementMap_t::const_iterator it = map_.begin ();
+              it != map_.end (); ++it) {
+            os << it->first << " : " << *(it->second) << std::endl;
+          }
+          return os;
+        }
+
+      protected:
+        /// Constructor
+        Container () : map_ ()
+        {}
+
+      private:
+        ElementMap_t map_;
+    }; // class Container
+  } // namespace core
+} // namespace hpp
+#endif // HPP_CORE_CONTAINER_HH

--- a/include/hpp/core/distance.hh
+++ b/include/hpp/core/distance.hh
@@ -22,6 +22,7 @@
 # include <hpp/model/fwd.hh>
 # include <hpp/core/fwd.hh>
 # include <hpp/core/config.hh>
+# include <hpp/core/node.hh>
 
 namespace hpp {
   namespace core {
@@ -37,6 +38,11 @@ namespace hpp {
 	return impl_distance (q1, q2);
       }
 
+      value_type operator () (NodePtr_t n1, NodePtr_t n2) const
+      {
+	return impl_distance (n1, n2);
+      }
+
       virtual DistancePtr_t clone () const = 0;
       
     protected:
@@ -47,6 +53,10 @@ namespace hpp {
       /// Derived class should implement this function
       virtual value_type impl_distance (ConfigurationIn_t q1,
 				    ConfigurationIn_t q2) const = 0;
+      virtual value_type impl_distance (NodePtr_t n1, NodePtr_t n2) const
+      {
+        return impl_distance (*n1->configuration(), *n2->configuration());
+      }
     }; // class Distance
     /// \}
   } //   namespace core

--- a/include/hpp/core/distance.hh
+++ b/include/hpp/core/distance.hh
@@ -32,7 +32,7 @@ namespace hpp {
     /// Abstract class for distance between configurations
     class HPP_CORE_DLLAPI Distance {
     public:
-      virtual value_type operator () (ConfigurationIn_t q1,
+      value_type operator () (ConfigurationIn_t q1,
 				  ConfigurationIn_t q2) const
       {
 	return impl_distance (q1, q2);

--- a/include/hpp/core/fwd.hh
+++ b/include/hpp/core/fwd.hh
@@ -164,8 +164,8 @@ namespace hpp {
     typedef std::pair<size_type, size_type> SizeInterval_t;
     typedef std::vector < SizeInterval_t > SizeIntervals_t;
     typedef std::vector < SizeIntervals_t > IntervalsContainer_t;
-    typedef std::list <Node*> Nodes_t;
     typedef Node* NodePtr_t;
+    typedef std::list <NodePtr_t> Nodes_t;
     typedef model::ObjectVector_t ObjectVector_t;
     typedef boost::shared_ptr <Path> PathPtr_t;
     typedef boost::shared_ptr <const Path> PathConstPtr_t;

--- a/include/hpp/core/interpolated-path.hh
+++ b/include/hpp/core/interpolated-path.hh
@@ -126,10 +126,11 @@ namespace hpp {
       }
 
       /// Extraction/Reversion of a sub-path
-      /// \param subInterval interval of definition of the extract path
-      /// If upper bound of subInterval is smaller than lower bound,
-      /// result is reversed.
-      virtual PathPtr_t extract (const interval_t& subInterval) const;
+      /// See Path::extract
+      virtual PathPtr_t extract (const interval_t& subInterval) const
+        throw (projection_error);
+
+      virtual PathPtr_t reverse () const;
 
       /// Return the internal robot.
       DevicePtr_t device () const;

--- a/include/hpp/core/nearest-neighbor.hh
+++ b/include/hpp/core/nearest-neighbor.hh
@@ -34,6 +34,14 @@ namespace hpp {
 				connectedComponent,
 			       value_type& distance) = 0;
 
+      /// \param[out] distance to the Kth closest neighbor
+      /// \return the K nearest neighbors
+      virtual Nodes_t KnearestSearch (const ConfigurationPtr_t& configuration,
+			              const ConnectedComponentPtr_t&
+                                        connectedComponent,
+                                      const std::size_t K,
+			              value_type& distance) = 0;
+
       // merge two connected components in the whole tree
       virtual void merge (ConnectedComponentPtr_t cc1,
 			  ConnectedComponentPtr_t cc2) = 0;

--- a/include/hpp/core/nearest-neighbor.hh
+++ b/include/hpp/core/nearest-neighbor.hh
@@ -34,9 +34,22 @@ namespace hpp {
 				connectedComponent,
 			       value_type& distance) = 0;
 
+      virtual NodePtr_t search (const NodePtr_t& node,
+			       const ConnectedComponentPtr_t&
+				connectedComponent,
+			       value_type& distance) = 0;
+
       /// \param[out] distance to the Kth closest neighbor
       /// \return the K nearest neighbors
       virtual Nodes_t KnearestSearch (const ConfigurationPtr_t& configuration,
+			              const ConnectedComponentPtr_t&
+                                        connectedComponent,
+                                      const std::size_t K,
+			              value_type& distance) = 0;
+
+      /// \param[out] distance to the Kth closest neighbor
+      /// \return the K nearest neighbors
+      virtual Nodes_t KnearestSearch (const NodePtr_t& node,
 			              const ConnectedComponentPtr_t&
                                         connectedComponent,
                                       const std::size_t K,

--- a/include/hpp/core/node.hh
+++ b/include/hpp/core/node.hh
@@ -53,6 +53,15 @@ namespace hpp {
       const Edges_t& outEdges () const;
       /// Access to inEdges
       const Edges_t& inEdges () const;
+      /// Check whether otherNode is an out-neighbor of this node
+      /// Node B is an out-neighbor of node A if node A has an outgoing edge
+      /// going to B.
+      bool isOutNeighbor (const NodePtr_t& n) const;
+      /// Check whether this node is an in-neighbor of otherNode
+      /// Node B is an out-neighbor of node A if node A has an ingoing edge
+      /// going to B.
+      bool isInNeighbor (const NodePtr_t& n) const;
+
       ConfigurationPtr_t configuration () const;
       /// Print node in a stream
       std::ostream& print (std::ostream& os) const;

--- a/include/hpp/core/node.hh
+++ b/include/hpp/core/node.hh
@@ -53,12 +53,12 @@ namespace hpp {
       const Edges_t& outEdges () const;
       /// Access to inEdges
       const Edges_t& inEdges () const;
-      /// Check whether otherNode is an out-neighbor of this node
+      /// Check whether otherNode is an out-neighbor of this node.
       /// Node B is an out-neighbor of node A if node A has an outgoing edge
       /// going to B.
       bool isOutNeighbor (const NodePtr_t& n) const;
-      /// Check whether this node is an in-neighbor of otherNode
-      /// Node B is an out-neighbor of node A if node A has an ingoing edge
+      /// Check whether otherNode is an in-neighbor of this node.
+      /// Node B is an in-neighbor of node A if node A has an ingoing edge
       /// going to B.
       bool isInNeighbor (const NodePtr_t& n) const;
 

--- a/include/hpp/core/parser/roadmap-factory.hh
+++ b/include/hpp/core/parser/roadmap-factory.hh
@@ -66,6 +66,8 @@ namespace hpp {
             }
           };
 
+          virtual bool finishAttributes ();
+
           virtual void finishTags ();
 
           RoadmapFactory (const DevicePtr_t& robot, RoadmapPtr_t roadmap,
@@ -85,6 +87,8 @@ namespace hpp {
 
           typedef std::vector <std::size_t> SizeVector_t;
           SizeVector_t permutation_;
+
+          size_type extraCSsize_;
 
           typedef std::vector <NodePtr_t> Nodes_t;
           typedef std::vector <EdgePtr_t> Edges_t;

--- a/include/hpp/core/parser/roadmap-factory.hh
+++ b/include/hpp/core/parser/roadmap-factory.hh
@@ -37,45 +37,39 @@ namespace hpp {
       typedef hpp::util::parser::SequenceFactory<double> ConfigurationFactory;
       typedef hpp::util::parser::SequenceFactory<unsigned int> IdSequence;
 
-      void writeRoadmap (std::ostream& o, const RoadmapPtr_t roadmap,
-          const DevicePtr_t robot);
+      void writeRoadmap (std::ostream& o, const ProblemPtr_t& problem,
+          const RoadmapPtr_t& roadmap);
 
-      RoadmapPtr_t readRoadmap (const std::string& filename, const DistancePtr_t distance,
-          const DevicePtr_t robot);
+      /// Read a roadmap from a file.
+      RoadmapPtr_t readRoadmap (const std::string& filename,
+          const ProblemPtr_t& problem);
 
       class HPP_CORE_DLLAPI RoadmapFactory : public ObjectFactory {
         public:
           typedef ::hpp::util::parser::ObjectFactory Parent_t;
 
-          RoadmapFactory (const DistancePtr_t& distance,
-              const DevicePtr_t& robot, ObjectFactory* parent,
+          RoadmapFactory (const ProblemPtr_t& problem, ObjectFactory* parent,
               const XMLElement* element);
 
           RoadmapPtr_t roadmap () const {
             return roadmap_;
           }
 
-          struct ArgumentParser {
-            static DistancePtr_t d_;
-            static DevicePtr_t r_;
-            // ArgumentParser (const DistancePtr_t& d,
-              // const DevicePtr_t& r) : d_ (d), r_ (r) {}
-            static ObjectFactory* create (ObjectFactory* parent = NULL,
-                const XMLElement* element = NULL) {
-              return new RoadmapFactory (d_, r_, parent, element);
-            }
-          };
+          static ObjectFactory* create (const ProblemPtr_t& p,
+              ObjectFactory* parent, const XMLElement* el)
+          {
+            return new RoadmapFactory (p, parent, el);
+          }
 
           virtual bool finishAttributes ();
 
           virtual void finishTags ();
 
-          RoadmapFactory (const DevicePtr_t& robot, RoadmapPtr_t roadmap,
-              ObjectFactory* parent = NULL);
+          RoadmapFactory (const ProblemPtr_t& problem,
+              const RoadmapPtr_t& roadmap, ObjectFactory* parent = NULL);
 
         private:
-          DistancePtr_t distance_;
-          DevicePtr_t robot_;
+          ProblemPtr_t problem_;
 
           void computePermutation (const std::vector <std::string>& jointNames);
           ConfigurationPtr_t permuteAndCreateConfiguration

--- a/include/hpp/core/path-vector.hh
+++ b/include/hpp/core/path-vector.hh
@@ -111,7 +111,8 @@ namespace hpp {
 
       /// Extraction of a sub-path
       /// \param subInterval interval of definition of the extract path
-      virtual PathPtr_t extract (const interval_t& subInterval) const;
+      virtual PathPtr_t extract (const interval_t& subInterval) const
+        throw (projection_error);
 
       /// Get the initial configuration
       virtual Configuration_t initial () const

--- a/include/hpp/core/path.hh
+++ b/include/hpp/core/path.hh
@@ -24,6 +24,7 @@
 # include <hpp/core/config.hh>
 # include <hpp/core/constraint-set.hh>
 # include <hpp/core/deprecated.hh>
+# include <hpp/core/projection-error.hh>
 
 namespace hpp {
   namespace core {
@@ -65,7 +66,11 @@ namespace hpp {
       /// \param subInterval interval of definition of the extract path
       /// If upper bound of subInterval is smaller than lower bound,
       /// result is reversed.
-      virtual PathPtr_t extract (const interval_t& subInterval) const;
+      /// \exception projection_error is thrown when an end configuration of
+      ///                             the returned path could not be computed
+      ///                             due to projection failure.
+      virtual PathPtr_t extract (const interval_t& subInterval) const
+        throw (projection_error);
 
       /// Reversion of a path
       /// \return a new path that is this one reversed.

--- a/include/hpp/core/problem-solver.hh
+++ b/include/hpp/core/problem-solver.hh
@@ -46,6 +46,8 @@ namespace hpp {
       PathProjectorBuilder_t;
     typedef boost::function <ConfigurationShooterPtr_t (const DevicePtr_t&) >
       ConfigurationShooterBuilder_t;
+    typedef boost::function <SteeringMethodPtr_t (const DevicePtr_t&) >
+      SteeringMethodBuilder_t;
 
     /// Set and solve a path planning problem
     ///
@@ -58,11 +60,10 @@ namespace hpp {
       public Container <PathValidationBuilder_t>,
       public Container <PathProjectorBuilder_t>,
       public Container <ConfigurationShooterBuilder_t>,
-      public Container <NumericalConstraintPtr_t>
+      public Container <NumericalConstraintPtr_t>,
+      public Container <SteeringMethodBuilder_t>
     {
     public:
-      typedef boost::function <SteeringMethodPtr_t (const DevicePtr_t&) >
-	SteeringMethodBuilder_t;
 
       typedef std::vector <PathOptimizerPtr_t> PathOptimizers_t;
       typedef std::vector <std::string> PathOptimizerTypes_t;
@@ -111,7 +112,7 @@ namespace hpp {
       void addSteeringMethodType (const std::string& type,
 			       const SteeringMethodBuilder_t& builder)
       {
-	steeringMethodFactory_ [type] = builder;
+	add <SteeringMethodBuilder_t> (type, builder);
       }
       /// Set configuration shooter type
       void configurationShooterType (const std::string& type);
@@ -557,9 +558,6 @@ namespace hpp {
       /// Path planner
       std::string pathPlannerType_;
     private:
-      /// Map (string , constructor of steering method)
-      typedef std::map <std::string, SteeringMethodBuilder_t >
-        SteeringMethodFactory_t;
       /// Shared pointer to initial configuration.
       ConfigurationPtr_t initConf_;
       /// Shared pointer to goal configuration.
@@ -575,8 +573,6 @@ namespace hpp {
       std::string pathValidationType_;
       /// Tolerance of path validation
       value_type pathValidationTolerance_;
-      /// Steering Method factory
-      SteeringMethodFactory_t steeringMethodFactory_;
       /// Store obstacles until call to solve.
       ObjectVector_t collisionObstacles_;
       ObjectVector_t distanceObstacles_;

--- a/include/hpp/core/problem-solver.hh
+++ b/include/hpp/core/problem-solver.hh
@@ -46,7 +46,7 @@ namespace hpp {
       PathProjectorBuilder_t;
     typedef boost::function <ConfigurationShooterPtr_t (const DevicePtr_t&) >
       ConfigurationShooterBuilder_t;
-    typedef boost::function <SteeringMethodPtr_t (const DevicePtr_t&) >
+    typedef boost::function <SteeringMethodPtr_t (const ProblemPtr_t&) >
       SteeringMethodBuilder_t;
 
     /// Set and solve a path planning problem

--- a/include/hpp/core/problem-solver.hh
+++ b/include/hpp/core/problem-solver.hh
@@ -596,6 +596,8 @@ namespace hpp {
       DistanceBetweenObjectsPtr_t distanceBetweenObjects_;
       /// Store latest instance created by static method create
       static ProblemSolverPtr_t latest_;
+
+      void initProblem ();
     }; // class ProblemSolver
   } // namespace core
 } // namespace hpp

--- a/include/hpp/core/projection-error.hh
+++ b/include/hpp/core/projection-error.hh
@@ -15,6 +15,9 @@
 // hpp-core  If not, see
 // <http://www.gnu.org/licenses/>.
 
+#ifndef HPP_CORE_PROJECTION_ERROR_HH
+#define HPP_CORE_PROJECTION_ERROR_HH
+
 #include <exception>
 
 namespace hpp {
@@ -36,3 +39,5 @@ namespace hpp {
     };
   } // namespace core
 } // namespace hpp
+
+#endif // HPP_CORE_PROJECTION_ERROR_HH

--- a/include/hpp/core/steering-method-straight.hh
+++ b/include/hpp/core/steering-method-straight.hh
@@ -19,6 +19,9 @@
 #ifndef HPP_CORE_STEERING_METHOD_STRAIGHT_HH
 # define HPP_CORE_STEERING_METHOD_STRAIGHT_HH
 
+# include <hpp/core/config.hh>
+# include <hpp/core/fwd.hh>
+# include <hpp/core/problem.hh>
 # include <hpp/core/steering-method.hh>
 # include <hpp/core/straight-path.hh>
 # include <hpp/core/weighed-distance.hh>
@@ -34,9 +37,9 @@ namespace hpp {
     {
     public:
       /// Create instance and return shared pointer
-      static SteeringMethodStraightPtr_t create (const DevicePtr_t& device)
+      static SteeringMethodStraightPtr_t create (const ProblemPtr_t& problem)
       {
-	SteeringMethodStraight* ptr = new SteeringMethodStraight (device);
+	SteeringMethodStraight* ptr = new SteeringMethodStraight (problem);
 	SteeringMethodStraightPtr_t shPtr (ptr);
 	ptr->init (shPtr);
 	return shPtr;
@@ -44,6 +47,7 @@ namespace hpp {
       /// Create instance and return shared pointer
       static SteeringMethodStraightPtr_t create
 	(const DevicePtr_t& device, const WeighedDistancePtr_t& distance)
+        HPP_CORE_DEPRECATED
       {
 	SteeringMethodStraight* ptr = new SteeringMethodStraight (device,
 								  distance);
@@ -70,30 +74,28 @@ namespace hpp {
       virtual PathPtr_t impl_compute (ConfigurationIn_t q1,
 				      ConfigurationIn_t q2) const
       {
-        value_type length = (*distance_) (q1, q2);
-        PathPtr_t path = StraightPath::create (device_.lock (), q1, q2, length,
-					       constraints ());
+        value_type length = (*problem_->distance()) (q1, q2);
+        PathPtr_t path = StraightPath::create
+          (problem_->robot(), q1, q2, length, constraints ());
         return path;
       }
     protected:
       /// Constructor with robot
       /// Weighed distance is created from robot
-      SteeringMethodStraight (const DevicePtr_t& device) :
-	SteeringMethod (), device_ (device),
-	distance_ (WeighedDistance::create (device)), weak_ ()
+      SteeringMethodStraight (const ProblemPtr_t& problem) :
+	SteeringMethod (problem), weak_ ()
       {
       }
       /// Constructor with weighed distance
       SteeringMethodStraight (const DevicePtr_t& device,
 			      const WeighedDistancePtr_t& distance) :
-	SteeringMethod (), device_ (device),
-	distance_ (distance), weak_ ()
+	SteeringMethod (new Problem (device)), weak_ ()
       {
+        problem_->distance (distance);
       }
       /// Copy constructor
       SteeringMethodStraight (const SteeringMethodStraight& other) :
-	SteeringMethod (other), device_ (other.device_),
-	distance_ (other.distance_), weak_ ()
+	SteeringMethod (other), weak_ ()
       {
       }
 
@@ -103,9 +105,9 @@ namespace hpp {
 	SteeringMethod::init (weak);
 	weak_ = weak;
       }
+
     private:
-      DeviceWkPtr_t device_;
-      WeighedDistancePtr_t distance_;
+
       SteeringMethodStraightWkPtr_t weak_;
     }; // SteeringMethodStraight
     /// \}

--- a/include/hpp/core/steering-method.hh
+++ b/include/hpp/core/steering-method.hh
@@ -19,6 +19,7 @@
 #ifndef HPP_CORE_STEERING_METHOD_HH
 # define HPP_CORE_STEERING_METHOD_HH
 
+# include <hpp/core/fwd.hh>
 # include <hpp/core/path.hh>
 
 namespace hpp {
@@ -66,9 +67,10 @@ namespace hpp {
 
     protected:
       /// Constructor
-      SteeringMethod () : constraints_ (), weak_ ()
-	{
-	}
+      SteeringMethod (ProblemPtr_t problem) :
+        problem_ (problem), constraints_ (), weak_ ()
+      {
+      }
       /// Copy constructor
       ///
       /// Constraints are copied
@@ -87,6 +89,9 @@ namespace hpp {
       {
 	weak_ = weak;
       }
+
+      ProblemPtr_t problem_;
+
     private:
       /// Set of constraints to apply on the paths produced
       ConstraintSetPtr_t constraints_;

--- a/include/hpp/core/steering-method.hh
+++ b/include/hpp/core/steering-method.hh
@@ -74,7 +74,8 @@ namespace hpp {
       /// Copy constructor
       ///
       /// Constraints are copied
-      SteeringMethod (const SteeringMethod& other) : constraints_ (), weak_ ()
+      SteeringMethod (const SteeringMethod& other) :
+        problem_ (other.problem_), constraints_ (), weak_ ()
 	{
 	  if (other.constraints_) {
 	    constraints_ = HPP_DYNAMIC_PTR_CAST (ConstraintSet,

--- a/include/hpp/core/straight-path.hh
+++ b/include/hpp/core/straight-path.hh
@@ -119,7 +119,8 @@ namespace hpp {
       /// \param subInterval interval of definition of the extract path
       /// If upper bound of subInterval is smaller than lower bound,
       /// result is reversed.
-      virtual PathPtr_t extract (const interval_t& subInterval) const;
+      virtual PathPtr_t extract (const interval_t& subInterval) const
+        throw (projection_error);
 
       /// Modify initial configuration
       /// \param initial new initial configuration

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ SET(${LIBRARY_NAME}_SOURCES
   extracted-path.hh
   joint-bound-validation.cc
   nearest-neighbor/basic.hh
+  nearest-neighbor/basic.cc
   nearest-neighbor/k-d-tree.cc
   nearest-neighbor/k-d-tree.hh
   node.cc

--- a/src/config-projector.cc
+++ b/src/config-projector.cc
@@ -23,6 +23,7 @@
 #include <hpp/model/device.hh>
 #include <hpp/model/joint.hh>
 #include <hpp/constraints/svd.hh>
+#include <hpp/constraints/macros.hh>
 #include <hpp/core/config-projector.hh>
 #include <hpp/core/constraint-set.hh>
 #include <hpp/constraints/differentiable-function.hh>

--- a/src/continuous-collision-checking/progressive.cc
+++ b/src/continuous-collision-checking/progressive.cc
@@ -176,6 +176,7 @@ namespace hpp {
 	  value_type lastValidTime = tmax;
 	  value_type t = tmax;
 	  unsigned finished = 0;
+          if (t <= tmin) finished++;
 	  while (finished < 2 && valid) {
 	    Configuration_t q = (*path) (t);
 	    value_type tprev = t;
@@ -316,6 +317,7 @@ namespace hpp {
 	  value_type t = tmin;
 	  unsigned finished = 0;
           Configuration_t q (path->outputSize ());
+          if (t >= tmax) finished++;
 	  while (finished < 2 && valid) {
 	    bool success = (*path) (q, t);
 	    value_type tprev = t;

--- a/src/continuous-collision-checking/progressive/body-pair-collision.hh
+++ b/src/continuous-collision-checking/progressive/body-pair-collision.hh
@@ -489,6 +489,10 @@ namespace hpp {
 	    value_type t0 = path_->timeRange ().first;
 	    value_type t1 = path_->timeRange ().second;
 	    value_type T = t1 - t0;
+            if (T == 0) {
+              maximalVelocity_ = std::numeric_limits<value_type>::infinity();
+              return;
+            }
 	    Configuration_t q1 = (*path_) (t0);
 	    Configuration_t q2 = (*path_) (t1);
 

--- a/src/diffusing-planner.cc
+++ b/src/diffusing-planner.cc
@@ -154,7 +154,6 @@ namespace hpp {
 	  // Insert new path to q_near in roadmap
 	  value_type t_final = validPath->timeRange ().second;
 	  if (t_final != path->timeRange ().first) {
-	    bool success;
 	    ConfigurationPtr_t q_new (new Configuration_t
 				      (validPath->end ()));
 	    if (!pathValid || !belongs (q_new, newNodes)) {

--- a/src/extracted-path.hh
+++ b/src/extracted-path.hh
@@ -87,6 +87,7 @@ namespace hpp {
       }
 
       virtual PathPtr_t extract (const interval_t& subInterval) const
+        throw (projection_error)
       {
 	ExtractedPathPtr_t path = createCopy (weak_.lock ());
 	bool reversed = subInterval.first > subInterval.second ? true : false;

--- a/src/interpolated-path.cc
+++ b/src/interpolated-path.cc
@@ -16,8 +16,7 @@
 
 #include <hpp/util/debug.hh>
 #include <hpp/model/device.hh>
-#include <hpp/model/joint.hh>
-#include <hpp/model/joint-configuration.hh>
+#include <hpp/model/configuration.hh>
 #include <hpp/core/config-projector.hh>
 #include <hpp/core/interpolated-path.hh>
 #include <hpp/core/projection-error.hh>
@@ -124,14 +123,7 @@ namespace hpp {
       const value_type T = itA->first - itB->first;
       const value_type u = (param - itB->first) / T;
 
-      // Loop over device joint and interpolate
-      const JointVector_t& jv (device_->getJointVector ());
-      for (model::JointVector_t::const_iterator itJoint = jv.begin ();
-	   itJoint != jv.end (); ++itJoint) {
-	std::size_t rank = (*itJoint)->rankInConfiguration ();
-	(*itJoint)->configuration ()->interpolate
-	  (itB->second, itA->second, u, rank, result);
-      }
+      model::interpolate (device_, itB->second, itA->second, u, result);
       return true;
     }
 

--- a/src/interpolated-path.cc
+++ b/src/interpolated-path.cc
@@ -136,6 +136,7 @@ namespace hpp {
     }
 
     PathPtr_t InterpolatedPath::extract (const interval_t& subInterval) const
+        throw (projection_error)
     {
       // Length is assumed to be proportional to interval range
       const bool reverse = (subInterval.first > subInterval.second);
@@ -160,6 +161,26 @@ namespace hpp {
       else
         for (; it->first < tmax; ++it)
           result->insert (it->first - tmin, it->second); 
+
+      return result;
+    }
+
+    PathPtr_t InterpolatedPath::reverse () const
+    {
+      const value_type& l = length();
+
+      InterpolatedPathPtr_t result =
+        InterpolatedPath::create (device_, end(), initial(), length(),
+					       constraints ());
+
+      if (configs_.size () > 2) {
+        InterpolationPoints_t::const_reverse_iterator it = configs_.rbegin();
+        ++it;
+        InterpolationPoints_t::const_reverse_iterator itEnd = configs_.rend();
+        --itEnd;
+        for (; it != itEnd; ++it)
+          result->insert (l - it->first, it->second); 
+      }
 
       return result;
     }

--- a/src/locked-joint.cc
+++ b/src/locked-joint.cc
@@ -16,6 +16,8 @@
 
 #include "hpp/core/locked-joint.hh"
 
+#include <sstream>
+
 #include <hpp/util/debug.hh>
 #include <hpp/model/configuration.hh>
 #include <hpp/model/device.hh>
@@ -23,6 +25,13 @@
 
 namespace hpp {
   namespace core {
+    namespace {
+        template <typename T>
+	std::string numToStr (const T& v) {
+ 	  std::stringstream ss; ss<<v; return ss.str ();
+	}
+    }
+
     /// Copy object and return shared pointer to copy
     EquationPtr_t LockedJoint::copy () const
     {
@@ -128,7 +137,7 @@ namespace hpp {
     LockedJoint::LockedJoint (const DevicePtr_t& dev, const size_type index,
         vectorIn_t value) :
       Equation (Equality::create (), vector_t::Zero (value.size())),
-      jointName_ (dev->name() + "_extraDof"),
+      jointName_ (dev->name() + "_extraDof" + numToStr (index)),
       rankInConfiguration_
       (dev->configSize () - dev->extraConfigSpace().dimension() + index),
       rankInVelocity_

--- a/src/nearest-neighbor/basic.cc
+++ b/src/nearest-neighbor/basic.cc
@@ -1,0 +1,95 @@
+// Copyright (c) 2015 CNRS
+// Authors: Joseph Mirabel
+//
+// This file is part of hpp-core
+// hpp-core is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-core is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-core  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#include "../src/nearest-neighbor/basic.hh"
+
+# include <limits>
+# include <queue>
+
+# include <hpp/core/distance.hh>
+# include <hpp/core/connected-component.hh>
+
+namespace hpp {
+  namespace core {
+    namespace nearestNeighbor {
+      namespace {
+        typedef std::pair <value_type, NodePtr_t> DistAndNode_t;
+        struct DistAndNodeComp_t {
+          bool operator () (const DistAndNode_t& r,
+              const DistAndNode_t& l) {
+            return r.first < l.first;
+          }
+        };
+        typedef std::priority_queue <DistAndNode_t, std::vector <DistAndNode_t>,
+                DistAndNodeComp_t > Queue_t;
+      }
+
+      NodePtr_t Basic::search (const ConfigurationPtr_t& configuration,
+			       const ConnectedComponentPtr_t&
+				connectedComponent,
+			       value_type& distance)
+      {
+	NodePtr_t result = NULL;
+	distance = std::numeric_limits <value_type>::infinity ();
+        const Distance& dist = *distance_;
+	for (Nodes_t::const_iterator itNode =
+	       connectedComponent->nodes ().begin ();
+	     itNode != connectedComponent->nodes ().end (); ++itNode) {
+	  value_type d = dist (*(*itNode)->configuration (),
+				       *configuration);
+	  if (d < distance) {
+	    distance = d;
+	    result = *itNode;
+	  }
+	}
+	assert (result);
+	return result;
+      }
+
+      Nodes_t Basic::KnearestSearch (const ConfigurationPtr_t& configuration,
+          const ConnectedComponentPtr_t&
+          connectedComponent,
+          const std::size_t K,
+          value_type& distance)
+      {
+        Queue_t ns;
+        distance = std::numeric_limits <value_type>::infinity ();
+        const Distance& dist = *distance_;
+        const Configuration_t& q = *configuration;
+        for (Nodes_t::const_iterator itNode =
+            connectedComponent->nodes ().begin ();
+            itNode != connectedComponent->nodes ().end (); ++itNode) {
+          value_type d = dist (*(*itNode)->configuration (), q);
+          if (ns.size () < K)
+            ns.push (DistAndNode_t (d, (*itNode)));
+          else {
+            if (ns.top().first > d) {
+              ns.pop ();
+              ns.push (DistAndNode_t (d, (*itNode)));
+            }
+          }
+        }
+        Nodes_t nodes;
+        if (ns.size() > 0) distance = ns.top ().first;
+        while (ns.size () > 0) {
+          nodes.push_back (ns.top().second); ns.pop ();
+        }
+        return nodes;
+      }
+    } // namespace nearestNeighbor
+  } // namespace core
+} // namespace hpp

--- a/src/nearest-neighbor/basic.hh
+++ b/src/nearest-neighbor/basic.hh
@@ -46,12 +46,23 @@ namespace hpp {
       {
       }
 
+      virtual NodePtr_t search (const NodePtr_t& node,
+			       const ConnectedComponentPtr_t&
+				connectedComponent,
+			       value_type& distance);
+
       virtual NodePtr_t search (const ConfigurationPtr_t& configuration,
 			       const ConnectedComponentPtr_t&
 				connectedComponent,
 			       value_type& distance);
 
       virtual Nodes_t KnearestSearch (const ConfigurationPtr_t& configuration,
+                                      const ConnectedComponentPtr_t&
+                                        connectedComponent,
+                                      const std::size_t K,
+                                      value_type& distance);
+
+      virtual Nodes_t KnearestSearch (const NodePtr_t& node,
                                       const ConnectedComponentPtr_t&
                                         connectedComponent,
                                       const std::size_t K,

--- a/src/nearest-neighbor/basic.hh
+++ b/src/nearest-neighbor/basic.hh
@@ -19,9 +19,7 @@
 #ifndef HPP_CORE_NEAREST_NEIGHBOR_BASIC_HH
 # define HPP_CORE_NEAREST_NEIGHBOR_BASIC_HH
 
-# include <limits>
 # include <hpp/core/fwd.hh>
-# include <hpp/core/distance.hh>
 # include <hpp/core/nearest-neighbor.hh>
 
 namespace hpp {
@@ -51,23 +49,13 @@ namespace hpp {
       virtual NodePtr_t search (const ConfigurationPtr_t& configuration,
 			       const ConnectedComponentPtr_t&
 				connectedComponent,
-			       value_type& distance)
-      {
-	NodePtr_t result = NULL;
-	distance = std::numeric_limits <value_type>::infinity ();
-	for (Nodes_t::const_iterator itNode =
-	       connectedComponent->nodes ().begin ();
-	     itNode != connectedComponent->nodes ().end (); ++itNode) {
-	  value_type d = (*distance_) (*(*itNode)->configuration (),
-				       *configuration);
-	  if (d < distance) {
-	    distance = d;
-	    result = *itNode;
-	  }
-	}
-	assert (result);
-	return result;
-      }
+			       value_type& distance);
+
+      virtual Nodes_t KnearestSearch (const ConfigurationPtr_t& configuration,
+                                      const ConnectedComponentPtr_t&
+                                        connectedComponent,
+                                      const std::size_t K,
+                                      value_type& distance);
 
       virtual void merge (ConnectedComponentPtr_t, ConnectedComponentPtr_t)
       {

--- a/src/nearest-neighbor/k-d-tree.cc
+++ b/src/nearest-neighbor/k-d-tree.cc
@@ -259,6 +259,19 @@ namespace hpp {
       return nearest;
     }
 
+    NodePtr_t KDTree::search (const NodePtr_t& node,
+			      const ConnectedComponentPtr_t& connectedComponent,
+                              value_type& minDistance) {
+      return search (node->configuration (), connectedComponent, minDistance);
+    }
+
+    Nodes_t KDTree::KnearestSearch (const NodePtr_t&,
+        const ConnectedComponentPtr_t&, const std::size_t,
+        value_type&)
+    {
+      assert (false && "K-nearest neighbor in KD-tree: unimplemented features");
+    }
+
     Nodes_t KDTree::KnearestSearch (const ConfigurationPtr_t&,
         const ConnectedComponentPtr_t&, const std::size_t,
         value_type&)

--- a/src/nearest-neighbor/k-d-tree.cc
+++ b/src/nearest-neighbor/k-d-tree.cc
@@ -259,6 +259,13 @@ namespace hpp {
       return nearest;
     }
 
+    Nodes_t KDTree::KnearestSearch (const ConfigurationPtr_t&,
+        const ConnectedComponentPtr_t&, const std::size_t,
+        value_type&)
+    {
+      assert (false && "K-nearest neighbor in KD-tree: unimplemented features");
+    }
+
     void KDTree::search (value_type boxDistance, value_type& minDistance,
 			 const ConfigurationPtr_t& configuration,
 			 const ConnectedComponentPtr_t& connectedComponent,

--- a/src/nearest-neighbor/k-d-tree.hh
+++ b/src/nearest-neighbor/k-d-tree.hh
@@ -54,6 +54,18 @@ namespace hpp {
 				connectedComponent,
 				value_type& minDistance);
 
+      // search nearest node
+      virtual NodePtr_t search (const NodePtr_t& configuration,
+			        const ConnectedComponentPtr_t&
+				connectedComponent,
+				value_type& minDistance);
+
+      virtual Nodes_t KnearestSearch (const NodePtr_t& configuration,
+                                      const ConnectedComponentPtr_t&
+                                        connectedComponent,
+                                      const std::size_t K,
+                                      value_type& distance);
+
       virtual Nodes_t KnearestSearch (const ConfigurationPtr_t& configuration,
                                       const ConnectedComponentPtr_t&
                                         connectedComponent,

--- a/src/nearest-neighbor/k-d-tree.hh
+++ b/src/nearest-neighbor/k-d-tree.hh
@@ -54,6 +54,13 @@ namespace hpp {
 				connectedComponent,
 				value_type& minDistance);
 
+      virtual Nodes_t KnearestSearch (const ConfigurationPtr_t& configuration,
+                                      const ConnectedComponentPtr_t&
+                                        connectedComponent,
+                                      const std::size_t K,
+                                      value_type& distance);
+
+
       // merge two connected components in the whole tree
       void merge(ConnectedComponentPtr_t cc1, ConnectedComponentPtr_t cc2);
       // Get distance function

--- a/src/node.cc
+++ b/src/node.cc
@@ -99,6 +99,22 @@ namespace hpp {
       return inEdges_;
     }
 
+    bool Node::isOutNeighbor (const NodePtr_t& n) const
+    {
+      for (Edges_t::const_iterator it=outEdges_.begin (); it != outEdges_.end ();
+	   ++it)
+	if ((*it)->to () == n) return true;
+      return false;
+    }
+
+    bool Node::isInNeighbor (const NodePtr_t& n) const
+    {
+      for (Edges_t::const_iterator it=inEdges_.begin (); it != inEdges_.end ();
+	   ++it)
+	if ((*it)->from () == n) return true;
+      return false;
+    }
+
     ConfigurationPtr_t Node::configuration () const
     {
       return configuration_;

--- a/src/path-projector/progressive.cc
+++ b/src/path-projector/progressive.cc
@@ -106,7 +106,7 @@ namespace hpp {
             break;
           }
           const Configuration_t& qb = toSplit->initial ();
-          curStep = step_;
+          curStep = step_ - Eigen::NumTraits<value_type>::epsilon ();
           curLength = std::numeric_limits <value_type>::max();
           size_t dicC = 0;
           /// Find the good length.

--- a/src/path-vector.cc
+++ b/src/path-vector.cc
@@ -103,6 +103,7 @@ namespace hpp {
     }
 
     PathPtr_t PathVector::extract (const interval_t& subInterval) const
+        throw (projection_error)
     {
       using std::make_pair;
       PathVectorPtr_t path = create (outputSize (), outputDerivativeSize ());

--- a/src/path.cc
+++ b/src/path.cc
@@ -77,6 +77,7 @@ namespace hpp {
 
 
     PathPtr_t Path::extract (const interval_t& subInterval) const
+        throw (projection_error)
     {
       if (subInterval == timeRange_)
 	return this->copy ();

--- a/src/path.cc
+++ b/src/path.cc
@@ -65,7 +65,11 @@ namespace hpp {
     {
       weak_ = self;
       if (constraints_ && constraints_->configProjector ()) {
-	constraints_->configProjector ()->rightHandSideFromConfig (initial ());
+	vector_t rhs = (
+            constraints_->configProjector()->rightHandSideFromConfig (initial())
+            + constraints_->configProjector()->rightHandSideFromConfig (end())
+            ) / 2;
+        constraints_->configProjector()->rightHandSide (rhs);
       }
     }
 

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -93,7 +93,7 @@ namespace hpp {
       add <ConfigurationShooterBuilder_t> ("BasicConfigurationShooter", BasicConfigurationShooter::create);
 
       add <SteeringMethodBuilder_t> ("SteeringMethodStraight", boost::bind(
-            static_cast<SteeringMethodStraightPtr_t (*)(const DevicePtr_t&)>
+            static_cast<SteeringMethodStraightPtr_t (*)(const ProblemPtr_t&)>
               (&SteeringMethodStraight::create), _1
             ));
 
@@ -365,7 +365,7 @@ namespace hpp {
           (robot_));
       // Set steeringMethod
       SteeringMethodPtr_t sm (
-         get <SteeringMethodBuilder_t> (steeringMethodType_) (robot_)
+         get <SteeringMethodBuilder_t> (steeringMethodType_) (problem_)
          );
       problem_->steeringMethod (sm);
       PathPlannerBuilder_t createPlanner =
@@ -414,7 +414,7 @@ namespace hpp {
         (get <ConfigurationShooterBuilder_t> (configurationShooterType_) (robot_));
       // Set steeringMethod
       SteeringMethodPtr_t sm (
-          get <SteeringMethodBuilder_t> (steeringMethodType_) (robot_)
+          get <SteeringMethodBuilder_t> (steeringMethodType_) (problem_)
           );
       problem_->steeringMethod (sm);
       PathPlannerBuilder_t createPlanner =

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -92,8 +92,10 @@ namespace hpp {
 
       add <ConfigurationShooterBuilder_t> ("BasicConfigurationShooter", BasicConfigurationShooter::create);
 
-      steeringMethodFactory_ ["SteeringMethodStraight"] =
-        boost::bind(static_cast<SteeringMethodStraightPtr_t (*)(const DevicePtr_t&)>(&SteeringMethodStraight::create), _1);
+      add <SteeringMethodBuilder_t> ("SteeringMethodStraight", boost::bind(
+            static_cast<SteeringMethodStraightPtr_t (*)(const DevicePtr_t&)>
+              (&SteeringMethodStraight::create), _1
+            ));
 
       // Store path optimization methods in map.
       add <PathOptimizerBuilder_t> ("RandomShortcut",     RandomShortcut::create);
@@ -121,7 +123,7 @@ namespace hpp {
 
     void ProblemSolver::steeringMethodType (const std::string& type)
     {
-      if (steeringMethodFactory_.find (type) == steeringMethodFactory_.end ()) {
+      if (!has <SteeringMethodBuilder_t> (type)) {
 	throw std::runtime_error (std::string ("No steering method with name ") +
 				  type);
       }
@@ -362,8 +364,10 @@ namespace hpp {
           get <ConfigurationShooterBuilder_t> (configurationShooterType_)
           (robot_));
       // Set steeringMethod
-      problem_->steeringMethod
-        (steeringMethodFactory_ [steeringMethodType_] (robot_));
+      SteeringMethodPtr_t sm (
+         get <SteeringMethodBuilder_t> (steeringMethodType_) (robot_)
+         );
+      problem_->steeringMethod (sm);
       PathPlannerBuilder_t createPlanner =
 	get <PathPlannerBuilder_t> (pathPlannerType_);
       pathPlanner_ = createPlanner (*problem_, roadmap_);
@@ -372,7 +376,6 @@ namespace hpp {
         get <PathProjectorBuilder_t> (pathProjectorType_);
       // Create a default steering method until we add a steering method
       // factory.
-      SteeringMethodPtr_t sm (SteeringMethodStraight::create (robot ()));
       PathProjectorPtr_t pathProjector_ =
         createProjector (problem_->distance (), sm, pathProjectorTolerance_);
       problem_->pathProjector (pathProjector_);
@@ -410,8 +413,10 @@ namespace hpp {
       problem_->configurationShooter
         (get <ConfigurationShooterBuilder_t> (configurationShooterType_) (robot_));
       // Set steeringMethod
-      problem_->steeringMethod
-        (steeringMethodFactory_ [steeringMethodType_] (robot_));
+      SteeringMethodPtr_t sm (
+          get <SteeringMethodBuilder_t> (steeringMethodType_) (robot_)
+          );
+      problem_->steeringMethod (sm);
       PathPlannerBuilder_t createPlanner =
         get <PathPlannerBuilder_t> (pathPlannerType_);
       pathPlanner_ = createPlanner (*problem_, roadmap_);
@@ -420,7 +425,6 @@ namespace hpp {
         get <PathProjectorBuilder_t> (pathProjectorType_);
       // Create a default steering method until we add a steering method
       // factory.
-      SteeringMethodPtr_t sm (SteeringMethodStraight::create (robot ()));
       PathProjectorPtr_t pathProjector_ =
         createProjector (problem_->distance (), sm, pathProjectorTolerance_);
       problem_->pathProjector (pathProjector_);

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -83,7 +83,7 @@ namespace hpp {
       pathOptimizerTypes_ (), pathOptimizers_ (),
       pathValidationType_ ("Discretized"), pathValidationTolerance_ (0.05),
       collisionObstacles_ (), distanceObstacles_ (), obstacleMap_ (),
-      errorThreshold_ (1e-4), maxIterations_ (20), numericalConstraintMap_ (),
+      errorThreshold_ (1e-4), maxIterations_ (20),
       passiveDofsMap_ (), comcMap_ (),
       distanceBetweenObjects_ ()
     {
@@ -282,7 +282,7 @@ namespace hpp {
 	  (robot_, constraintName, errorThreshold_, maxIterations_);
 	constraints_->addConstraint (configProjector);
       }
-      configProjector->add (numericalConstraintMap_ [functionName],
+      configProjector->add (numericalConstraint (functionName),
 			    SizeIntervals_t (0), priority);
     }
 

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -426,7 +426,9 @@ namespace hpp {
       // Create a default steering method until we add a steering method
       // factory.
       PathProjectorPtr_t pathProjector_ =
-        createProjector (problem_->distance (), sm, pathProjectorTolerance_);
+        createProjector (problem_->distance (), 
+            SteeringMethodStraight::create (problem_),
+            pathProjectorTolerance_);
       problem_->pathProjector (pathProjector_);
       /// create Path optimizer
       // Reset init and goal configurations

--- a/src/problem.cc
+++ b/src/problem.cc
@@ -40,7 +40,7 @@ namespace hpp {
       robot_ (robot),
       distance_ (WeighedDistance::create (robot)),
       initConf_ (), goalConfigurations_ (),
-      steeringMethod_ (SteeringMethodStraight::create (robot)),
+      steeringMethod_ (SteeringMethodStraight::create (this)),
       configValidations_ (ConfigValidations::create ()),
       pathValidation_ (DiscretizedCollisionChecking::create
 		       (robot, 0.05)),

--- a/src/random-shortcut.cc
+++ b/src/random-shortcut.cc
@@ -133,8 +133,11 @@ namespace hpp {
       }
       hppDout (info, "RandomShortcut:" << *result);
       for (std::size_t i = 0; i < result->numberPaths (); ++i) {
-        hppDout (info, "At rank " << i << ", constraints are " <<
-            *result->pathAtRank(i)->constraints());
+        if (result->pathAtRank(i)->constraints())
+          hppDout (info, "At rank " << i << ", constraints are " <<
+              *result->pathAtRank(i)->constraints());
+        else
+          hppDout (info, "At rank " << i << ", no constraints");
       }
       return result;
     }

--- a/src/roadmap.cc
+++ b/src/roadmap.cc
@@ -133,12 +133,12 @@ namespace hpp {
 			    const PathPtr_t& path)
     {
       EdgePtr_t edge = new Edge (from, to, path);
-      from->addOutEdge (edge);
-      to->addInEdge (edge);
+      if (!from->isOutNeighbor (to)) from->addOutEdge (edge);
+      if (!to->isInNeighbor  (from)) to->addInEdge (edge);
       edges_.push_back (edge);
       edge = new Edge (to, from, path->reverse ());
-      from->addInEdge (edge);
-      to->addOutEdge (edge);
+      if (!from->isInNeighbor  (to)) from->addInEdge (edge);
+      if (!to->isOutNeighbor (from)) to->addOutEdge (edge);
       edges_.push_back (edge);
     }
 
@@ -198,8 +198,8 @@ namespace hpp {
 				const PathPtr_t& path)
     {
       EdgePtr_t edge = new Edge (n1, n2, path);
-      n1->addOutEdge (edge);
-      n2->addInEdge (edge);
+      if (!n1->isOutNeighbor (n2)) n1->addOutEdge (edge);
+      if (!n2->isInNeighbor  (n1)) n2->addInEdge (edge);
       edges_.push_back (edge);
 
       ConnectedComponentPtr_t cc1 = n1->connectedComponent ();

--- a/src/straight-path.cc
+++ b/src/straight-path.cc
@@ -99,7 +99,9 @@ namespace hpp {
       }
       return true;
     }
+
     PathPtr_t StraightPath::extract (const interval_t& subInterval) const
+      throw (projection_error)
     {
       // Length is assumed to be proportional to interval range
       value_type l = fabs (subInterval.second - subInterval.first);

--- a/src/straight-path.cc
+++ b/src/straight-path.cc
@@ -18,8 +18,7 @@
 
 #include <hpp/util/debug.hh>
 #include <hpp/model/device.hh>
-#include <hpp/model/joint.hh>
-#include <hpp/model/joint-configuration.hh>
+#include <hpp/model/configuration.hh>
 #include <hpp/core/config-projector.hh>
 #include <hpp/core/straight-path.hh>
 #include <hpp/core/projection-error.hh>
@@ -89,14 +88,7 @@ namespace hpp {
       value_type u = param/timeRange ().second;
       if (timeRange ().second == 0)
 	u = 0;
-      // Loop over device joint and interpolate
-      const JointVector_t& jv (device_->getJointVector ());
-      for (model::JointVector_t::const_iterator itJoint = jv.begin ();
-	   itJoint != jv.end (); ++itJoint) {
-	std::size_t rank = (*itJoint)->rankInConfiguration ();
-	(*itJoint)->configuration ()->interpolate
-	  (initial_, end_, u, rank, result);
-      }
+      model::interpolate (device_, initial_, end_, u, result);
       return true;
     }
 

--- a/src/weighed-distance.cc
+++ b/src/weighed-distance.cc
@@ -170,6 +170,7 @@ namespace hpp {
 	  ++i;
 	}
       }
+      res+=(q1 - q2).tail (robot_->extraConfigSpace ().dimension()).squaredNorm ();
       return sqrt (res);
     }
   } //   namespace core

--- a/tests/roadmap-1.cc
+++ b/tests/roadmap-1.cc
@@ -23,10 +23,12 @@
 #include <hpp/model/joint.hh>
 #include <hpp/core/fwd.hh>
 #include <hpp/core/roadmap.hh>
+#include <hpp/core/problem.hh>
 #include <hpp/core/weighed-distance.hh>
 #include "hpp/core/basic-configuration-shooter.hh"
 #include <hpp/core/connected-component.hh>
 #include <hpp/core/node.hh>
+#include <hpp/core/nearest-neighbor.hh>
 #include <hpp/model/joint-configuration.hh>
 
 #include <hpp/core/steering-method-straight.hh>
@@ -41,6 +43,7 @@ using hpp::model::JointPtr_t;
 using hpp::model::Device;
 using hpp::model::DevicePtr_t;
 using hpp::model::JointTranslation;
+using hpp::core::Problem;
 using hpp::core::SteeringMethodStraight;
 using hpp::core::SteeringMethodStraightPtr_t;
 using hpp::core::RoadmapPtr_t;
@@ -76,7 +79,8 @@ BOOST_AUTO_TEST_CASE (Roadmap1) {
   xJoint->addChildJoint (yJoint);
 
   // Create steering method
-  SteeringMethodStraightPtr_t sm = SteeringMethodStraight::create (robot);
+  Problem p = Problem (robot);
+  SteeringMethodStraightPtr_t sm = SteeringMethodStraight::create (&p);
   // create roadmap
   hpp::core::DistancePtr_t distance (WeighedDistance::create
 				     (robot, boost::assign::list_of (1)(1)));

--- a/tests/roadmap-1.cc
+++ b/tests/roadmap-1.cc
@@ -281,6 +281,95 @@ BOOST_AUTO_TEST_CASE (Roadmap1) {
   std::cout << *r << std::endl;
 
 }
+
+BOOST_AUTO_TEST_CASE (nearestNeighbor) {
+  // Build robot
+  DevicePtr_t robot = Device::create("robot");
+  JointPtr_t xJoint = new JointTranslation <1> (fcl::Transform3f());
+  xJoint->isBounded(0,1);
+  xJoint->lowerBound(0,-3.);
+  xJoint->upperBound(0,3.);
+  JointPtr_t yJoint = new JointTranslation <1>
+    (fcl::Transform3f(fcl::Quaternion3f (sqrt (2)/2, 0, 0, sqrt(2)/2)));
+  yJoint->isBounded(0,1);
+  yJoint->lowerBound(0,-3.);
+  yJoint->upperBound(0,3.);
+
+  robot->rootJoint (xJoint);
+  xJoint->addChildJoint (yJoint);
+
+  // Create steering method
+  Problem p (robot);
+  SteeringMethodStraightPtr_t sm = SteeringMethodStraight::create (&p);
+  // create roadmap
+  hpp::core::DistancePtr_t distance (WeighedDistance::create
+				     (robot, boost::assign::list_of (1)(1)));
+  RoadmapPtr_t r = Roadmap::create (distance, robot);
+
+  std::vector <NodePtr_t> nodes;
+
+  // nodes [0]
+  ConfigurationPtr_t q (new Configuration_t (robot->configSize ()));
+  (*q) [0] = 0; (*q) [1] = 0;
+  nodes.push_back (r->addNode (q));
+
+  // nodes [1]
+  q = ConfigurationPtr_t (new Configuration_t (robot->configSize ()));
+  (*q) [0] = 1; (*q) [1] = 0;
+  nodes.push_back (r->addNode (q));
+
+  // nodes [2]
+  q = ConfigurationPtr_t (new Configuration_t (robot->configSize ()));
+  (*q) [0] = 0.5; (*q) [1] = 0.9;
+  nodes.push_back (r->addNode (q));
+
+  // nodes [3]
+  q = ConfigurationPtr_t (new Configuration_t (robot->configSize ()));
+  (*q) [0] = -0.1; (*q) [1] = -0.9;
+  nodes.push_back (r->addNode (q));
+
+  // nodes [4]
+  q = ConfigurationPtr_t (new Configuration_t (robot->configSize ()));
+  (*q) [0] = 1.5; (*q) [1] = 2.9;
+  nodes.push_back (r->addNode (q));
+
+  // nodes [5]
+  q = ConfigurationPtr_t (new Configuration_t (robot->configSize ()));
+  (*q) [0] = 2.5; (*q) [1] = 2.9;
+  nodes.push_back (r->addNode (q));
+  r->addGoalNode (nodes [5]->configuration ());
+
+  // nodes [6]
+  q = ConfigurationPtr_t (new Configuration_t (robot->configSize ()));
+  (*q) [0] = 0; (*q) [1] = 0.2;
+  nodes.push_back (r->addNode (q));
+  r->addGoalNode (nodes [6]->configuration ());
+
+  // 0 -> 1
+  addEdge (r, *sm, nodes, 0, 1);
+  // 1 -> 0
+  addEdge (r, *sm, nodes, 1, 0);
+  // 1 -> 2
+  addEdge (r, *sm, nodes, 1, 2);
+  // 2 -> 0
+  addEdge (r, *sm, nodes, 2, 0);
+  // 0 -> 3
+  addEdge (r, *sm, nodes, 0, 3);
+  // 3 -> 2
+  addEdge (r, *sm, nodes, 3, 2);
+
+  hpp::model::value_type dist;
+  using hpp::core::Nodes_t;
+  Nodes_t knearest = r->nearestNeighbor()->KnearestSearch
+    (nodes[0]->configuration(), nodes[0]->connectedComponent (), 3, dist);
+  for (Nodes_t::const_iterator it = knearest.begin (); it != knearest.end(); ++it) {
+    BOOST_MESSAGE ("q = [" << (*it)->configuration()->transpose() << "] - dist : " << (*distance) (*nodes[0]->configuration(), *(*it)->configuration()));
+  }
+  for (std::vector<NodePtr_t>::const_iterator it = nodes.begin (); it != nodes.end(); ++it) {
+    Configuration_t& q = *(*it)->configuration();
+    BOOST_MESSAGE ("[" << q.transpose() << "] - dist : " << (*distance) (*nodes[0]->configuration(), q));
+  }
+}
 BOOST_AUTO_TEST_SUITE_END()
 
 


### PR DESCRIPTION
The changes concerns:
* Homogenize factories in ProblemSolver;
* Add K-nearest neighbor search in class NearestNeighbor;
* Fix extra dofs interpolation (and other operations such as difference, integrate...);
* Roadmap::addEdge check whether a connection between two nodes exists before adding it;
* LockedJoint handle extra dofs;
* SteeringMethod is build with a Problem, not a Device (child classes may require information stored in Problem);
* Update Distance interface (normally, the update should be cosmetic in hpp-core and has effects only in hpp-manipulation).

TODO:
* In ConfigProjector, for now, the jacobian of the extra dofs is always 0.
* PathProjector cannot use the same steering method as the problem (cannot contain constraints)