### PR TITLE
Parameter map

### DIFF
--- a/include/hpp/core/problem.hh
+++ b/include/hpp/core/problem.hh
@@ -20,11 +20,14 @@
 #ifndef HPP_CORE_PROBLEM_HH
 # define HPP_CORE_PROBLEM_HH
 
+# include <boost/any.hpp>
+
 # include <hpp/model/device.hh>
 # include <hpp/util/pointer.hh>
 
 # include <hpp/core/config.hh>
 # include <hpp/core/steering-method.hh>
+# include <hpp/core/container.hh>
 
 namespace hpp {
   namespace core {
@@ -41,7 +44,8 @@ namespace hpp {
     /// \li a method to validate paths,
     /// \li a set of methods to validate configurations. Default methods are
     /// collision checking and joint bound checking.
-    class HPP_CORE_DLLAPI Problem
+    class HPP_CORE_DLLAPI Problem :
+      public Containers < boost::mpl::vector < boost::any > >
     {
     public:
       /// Create a path planning problem.
@@ -217,6 +221,24 @@ namespace hpp {
       /// Set the vector of objects considered for collision detection
       void collisionObstacles (const ObjectVector_t& collisionObstacles);
       /// \}
+
+      /// Get a parameter named name.
+      ///
+      /// \param name of the parameter.
+      /// \param defaultValue value returned if there is no parameter of this
+      ///        name
+      /// \throw boost::bad_any_cast if a parameter exists but has the wrong
+      ///        type.
+      template <typename T> T getParameter
+        (const std::string& name, const T& defaultValue) const
+        throw (boost::bad_any_cast)
+      {
+        if (has<boost::any>(name)) {
+          const boost::any& val = get<boost::any>(name);
+          return boost::any_cast<T>(val);
+        }
+        return defaultValue;
+      }
 
     private :
       /// The robot

--- a/include/hpp/core/problem.hh
+++ b/include/hpp/core/problem.hh
@@ -240,6 +240,22 @@ namespace hpp {
         return defaultValue;
       }
 
+      /// Set a parameter named name.
+      ///
+      /// \param name of the parameter.
+      /// \param value value of the parameter
+      /// \throw std::invalid_argument if a parameter exists but has a different
+      ///        type.
+      /// \note if you do not want any type checking but would rather erase any
+      ///       previous values, use
+      ///       \code
+      ///       add<boost::any>(name, (ExpectedType)value);
+      ///       \endcode
+      ///       If there is an ambiguity on the type, it is recommended to
+      ///       explicitely write it.
+      void setParameter (const std::string& name, const boost::any& value)
+        throw (std::invalid_argument);
+
     private :
       /// The robot
       DevicePtr_t robot_;

--- a/src/problem.cc
+++ b/src/problem.cc
@@ -181,5 +181,21 @@ namespace hpp {
 
     // ======================================================================
 
+    void Problem::setParameter (const std::string& name, const boost::any& value)
+      throw (std::invalid_argument)
+    {
+      if (has<boost::any>(name)) {
+        const boost::any& val = get<boost::any>(name);
+        if (value.type() != val.type()) {
+          std::string ret = "Wrong boost::any type. Expects ";
+          ret += val.type().name();
+          throw std::invalid_argument (ret.c_str());
+        }
+      }
+      add<boost::any> (name, value);
+    }
+
+    // ======================================================================
+
   } // namespace core
 } // namespace hpp


### PR DESCRIPTION
Here is a proposal of an implementation of a parameter map for HPP. Here are some motivations for what I did:
- I chose to implement it in `Problem` because it was the most convenient place in term of number of lines. Most objects encapsulating an algorithm have a pointer to the problem.
- There are two functions to add parameters:
  - `add<boost::any>(name, value)`: no type checking. It simply overwrites any previous value, regardless of its type.
  - `setParameter<type>(name, value)`: if a value exists at name `name`, then update it if the types match. Otherwise, throw an `std::invalid_argument`.

This is questionable but couldn't find a better implementation. Any comments or idea to improve it ?