### PR TITLE
add check to avoid addition of multiple objects of the same name

### DIFF
--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -538,6 +538,11 @@ namespace hpp {
     void ProblemSolver::addObstacle (const CollisionObjectPtr_t& object,
 				     bool collision, bool distance)
     {
+			if (obstacleMap_.find (object->name()) != obstacleMap_.end()) {
+					std::string errorMsg = "object with name " + object->name () +
+					" already added! Choose another name (prefix).";
+					throw std::runtime_error (errorMsg);
+			}
 
       if (collision){
 	collisionObstacles_.push_back (object);


### PR DESCRIPTION
Same check previously proposed for hpp-corbaserver but migrated to hpp-core