### PR TITLE
add method for oriented roadmap

### DIFF
--- a/include/hpp/core/nearest-neighbor.hh
+++ b/include/hpp/core/nearest-neighbor.hh
@@ -29,10 +29,21 @@ namespace hpp {
     public:
       virtual void clear () = 0;
       virtual void addNode (const NodePtr_t& node) = 0;
+
+      /**
+       * @brief search Return the closest node of the given configuration
+       * @param configuration
+       * @param connectedComponent
+       * @param distance
+       * @param reverse if true, compute distance from given configuration to nodes in roadmap,
+       *  if false from nodes in roadmap to given configuration
+       * @return
+       */
       virtual NodePtr_t search (const ConfigurationPtr_t& configuration,
 			       const ConnectedComponentPtr_t&
 				connectedComponent,
-			       value_type& distance) = 0;
+             value_type& distance,bool reverse = false) = 0;
+
 
       virtual NodePtr_t search (const NodePtr_t& node,
 			       const ConnectedComponentPtr_t&

--- a/include/hpp/core/roadmap.hh
+++ b/include/hpp/core/roadmap.hh
@@ -77,6 +77,20 @@ namespace hpp {
 				 const ConfigurationPtr_t& to,
 				 const PathPtr_t path);
 
+      /// Add a node and one edges
+      /// \param from node from which the edge starts,
+      /// \param to configuration to which the edge stops
+      /// \param path path between both configurations
+      /// \return node containing configuration <c>to</c>.
+      /// Add the oriented edge (from -> to)
+      /// \note this function simplifies the management of connected components
+      ///       since it adds the new node in the connected component of
+      ///       <c>from</c>.
+      NodePtr_t addNodeAndEdge (const NodePtr_t from,
+                 const ConfigurationPtr_t& to,
+                 const PathPtr_t path);
+
+
       /// Add a goal configuration
       /// \param config configuration
       /// If configuration is already in the roadmap, tag corresponding node

--- a/include/hpp/core/roadmap.hh
+++ b/include/hpp/core/roadmap.hh
@@ -48,17 +48,21 @@ namespace hpp {
 
       /// Get nearest node to a configuration in the roadmap.
       /// \param configuration configuration
+      /// \param reverse if true, compute distance from given configuration to nodes in roadmap,
+      /// if false from nodes in roadmap to given configuration
       /// \retval distance to the nearest node.
       NodePtr_t nearestNode (const ConfigurationPtr_t& configuration,
-			     value_type& minDistance);
+           value_type& minDistance, bool reverse = false);
 
       /// Get nearest node to a configuration in a connected component.
       /// \param configuration configuration
       /// \param connectedComponent the connected component
+      /// \param reverse if true, compute distance from given configuration to nodes in roadmap,
+      /// if false from nodes in roadmap to given configuration
       /// \retval distance to the nearest node.
       NodePtr_t nearestNode (const ConfigurationPtr_t& configuration,
 			     const ConnectedComponentPtr_t& connectedComponent,
-			     value_type& minDistance);
+           value_type& minDistance, bool reverse = false);
 
       /// Add a node and two edges
       /// \param from node from which the edge starts,

--- a/include/hpp/core/roadmap.hh
+++ b/include/hpp/core/roadmap.hh
@@ -77,7 +77,7 @@ namespace hpp {
 				 const ConfigurationPtr_t& to,
 				 const PathPtr_t path);
 
-      /// Add a node and one edges
+      /// Add a node and one edge
       /// \param from node from which the edge starts,
       /// \param to configuration to which the edge stops
       /// \param path path between both configurations
@@ -89,6 +89,19 @@ namespace hpp {
       NodePtr_t addNodeAndEdge (const NodePtr_t from,
                  const ConfigurationPtr_t& to,
                  const PathPtr_t path);
+
+      /// Add a node and one edge
+      /// \param from configuration from which the edge starts,
+      /// \param to node to which the edge stops
+      /// \param path path between both configurations
+      /// \return node containing configuration <c>from</c>.
+      /// Add the oriented edge (from -> to)
+      /// \note this function simplifies the management of connected components
+      ///       since it adds the new node in the connected component of
+      ///       <c>to</c>.
+      NodePtr_t addNodeAndEdge (const ConfigurationPtr_t& from,
+                      const NodePtr_t to,
+                      const PathPtr_t path);
 
 
       /// Add a goal configuration

--- a/src/nearest-neighbor/basic.cc
+++ b/src/nearest-neighbor/basic.cc
@@ -39,18 +39,21 @@ namespace hpp {
       }
 
       NodePtr_t Basic::search (const ConfigurationPtr_t& configuration,
-			       const ConnectedComponentPtr_t&
-				connectedComponent,
-			       value_type& distance)
+             const ConnectedComponentPtr_t&
+        connectedComponent,
+             value_type& distance, bool reverse)
       {
 	NodePtr_t result = NULL;
 	distance = std::numeric_limits <value_type>::infinity ();
         const Distance& dist = *distance_;
+        value_type d;
 	for (NodeVector_t::const_iterator itNode =
 	       connectedComponent->nodes ().begin ();
 	     itNode != connectedComponent->nodes ().end (); ++itNode) {
-	  value_type d = dist (*(*itNode)->configuration (),
-				       *configuration);
+    if(reverse)
+      d = dist ( *configuration, *(*itNode)->configuration ());
+    else
+      d = dist ( *(*itNode)->configuration (), *configuration);
 	  if (d < distance) {
 	    distance = d;
 	    result = *itNode;
@@ -61,9 +64,9 @@ namespace hpp {
       }
 
       NodePtr_t Basic::search (const NodePtr_t& node,
-			       const ConnectedComponentPtr_t&
-				connectedComponent,
-			       value_type& distance)
+             const ConnectedComponentPtr_t&
+        connectedComponent,
+             value_type& distance)
       {
 	NodePtr_t result = NULL;
 	distance = std::numeric_limits <value_type>::infinity ();

--- a/src/nearest-neighbor/basic.hh
+++ b/src/nearest-neighbor/basic.hh
@@ -47,14 +47,14 @@ namespace hpp {
       }
 
       virtual NodePtr_t search (const NodePtr_t& node,
-			       const ConnectedComponentPtr_t&
-				connectedComponent,
-			       value_type& distance);
+             const ConnectedComponentPtr_t&
+        connectedComponent,
+             value_type& distance);
 
       virtual NodePtr_t search (const ConfigurationPtr_t& configuration,
 			       const ConnectedComponentPtr_t&
 				connectedComponent,
-			       value_type& distance);
+             value_type& distance, bool reverse = false);
 
       virtual Nodes_t KnearestSearch (const ConfigurationPtr_t& configuration,
                                       const ConnectedComponentPtr_t&

--- a/src/nearest-neighbor/k-d-tree.cc
+++ b/src/nearest-neighbor/k-d-tree.cc
@@ -236,8 +236,8 @@ namespace hpp {
     }
 
     NodePtr_t KDTree::search (const ConfigurationPtr_t& configuration,
-			      const ConnectedComponentPtr_t& connectedComponent,
-                              value_type& minDistance) {
+            const ConnectedComponentPtr_t& connectedComponent,
+                              value_type& minDistance, bool reverse) {
       // Test if the configuration is in the root box
       for ( std::size_t i=0 ; i<dim_ ; i++ ) {
 	if ( (*configuration)[i] < lowerBounds_[i] || (*configuration)[i]
@@ -260,7 +260,7 @@ namespace hpp {
     }
 
     NodePtr_t KDTree::search (const NodePtr_t& node,
-			      const ConnectedComponentPtr_t& connectedComponent,
+            const ConnectedComponentPtr_t& connectedComponent,
                               value_type& minDistance) {
       return search (node->configuration (), connectedComponent, minDistance);
     }
@@ -282,7 +282,7 @@ namespace hpp {
     void KDTree::search (value_type boxDistance, value_type& minDistance,
 			 const ConfigurationPtr_t& configuration,
 			 const ConnectedComponentPtr_t& connectedComponent,
-			 NodePtr_t& nearest) {
+       NodePtr_t& nearest,bool reverse) {
       if ( boxDistance < minDistance*minDistance
 	   && nodesMap_.count(connectedComponent) > 0 ) {
 	// minDistance^2 because boxDistance is a squared distance
@@ -291,8 +291,10 @@ namespace hpp {
 	  for (Nodes_t::iterator itNode =
 		 nodesMap_[connectedComponent].begin ();
 	       itNode != nodesMap_[connectedComponent].end (); ++itNode) {
-	    distance = (*distance_) (*configuration,
-				     *((*itNode)->configuration ()));
+      if(reverse)
+        distance = (*distance_) (*configuration,*((*itNode)->configuration ()));
+      else
+        distance = (*distance_) (*((*itNode)->configuration ()),*configuration);
 	    if (distance < minDistance) {
 	      minDistance = distance;
 	      nearest = (*itNode);

--- a/src/nearest-neighbor/k-d-tree.hh
+++ b/src/nearest-neighbor/k-d-tree.hh
@@ -52,7 +52,7 @@ namespace hpp {
       virtual NodePtr_t search (const ConfigurationPtr_t& configuration,
 			        const ConnectedComponentPtr_t&
 				connectedComponent,
-				value_type& minDistance);
+        value_type& minDistance, bool reverse = false);
 
       // search nearest node
       virtual NodePtr_t search (const NodePtr_t& configuration,
@@ -122,9 +122,9 @@ namespace hpp {
 
       // search nearest node
       void search(value_type boxDistance, value_type& minDistance,
-		  const ConfigurationPtr_t& configuration,
-		  const ConnectedComponentPtr_t& connectedComponent,
-		  NodePtr_t& nearest);
+      const ConfigurationPtr_t& configuration,
+      const ConnectedComponentPtr_t& connectedComponent,
+      NodePtr_t& nearest, bool reverse = false);
 
 
     }; // class KDTree

--- a/src/roadmap.cc
+++ b/src/roadmap.cc
@@ -151,6 +151,15 @@ namespace hpp {
       return nodeTo;
     }
 
+    NodePtr_t Roadmap::addNodeAndEdge (const NodePtr_t from,
+                    const ConfigurationPtr_t& to,
+                    const PathPtr_t path)
+    {
+      NodePtr_t nodeTo = addNode (to, from->connectedComponent ());
+      addEdge (from, nodeTo, path);
+      return nodeTo;
+    }
+
     NodePtr_t
     Roadmap::nearestNode (const ConfigurationPtr_t& configuration,
         value_type& minDistance, bool reverse)

--- a/src/roadmap.cc
+++ b/src/roadmap.cc
@@ -153,7 +153,7 @@ namespace hpp {
 
     NodePtr_t
     Roadmap::nearestNode (const ConfigurationPtr_t& configuration,
-			  value_type& minDistance)
+        value_type& minDistance, bool reverse)
     {
       NodePtr_t closest = 0x0;
       minDistance = std::numeric_limits<value_type>::infinity ();
@@ -162,7 +162,7 @@ namespace hpp {
 	   itcc != connectedComponents_.end (); ++itcc) {
 	value_type distance;
 	NodePtr_t node;
-	node = nearestNeighbor_->search(configuration, *itcc, distance);
+  node = nearestNeighbor_->search(configuration, *itcc, distance,reverse);
 	if (distance < minDistance) {
 	  minDistance = distance;
 	  closest = node;
@@ -173,13 +173,13 @@ namespace hpp {
 
     NodePtr_t
     Roadmap::nearestNode (const ConfigurationPtr_t& configuration,
-			  const ConnectedComponentPtr_t& connectedComponent,
-			  value_type& minDistance)
+        const ConnectedComponentPtr_t& connectedComponent,
+        value_type& minDistance, bool reverse)
     {
       assert (connectedComponent);
       assert (connectedComponent->nodes ().size () != 0);
       NodePtr_t closest =
-	nearestNeighbor_->search(configuration, connectedComponent, minDistance);
+  nearestNeighbor_->search(configuration, connectedComponent, minDistance,reverse);
       return closest;
     }
     

--- a/src/roadmap.cc
+++ b/src/roadmap.cc
@@ -160,6 +160,15 @@ namespace hpp {
       return nodeTo;
     }
 
+    NodePtr_t Roadmap::addNodeAndEdge (const ConfigurationPtr_t& from,
+                    const NodePtr_t to,
+                    const PathPtr_t path)
+    {
+      NodePtr_t nodeFrom = addNode (from, to->connectedComponent ());
+      addEdge (nodeFrom, to, path);
+      return nodeFrom;
+    }
+
     NodePtr_t
     Roadmap::nearestNode (const ConfigurationPtr_t& configuration,
         value_type& minDistance, bool reverse)


### PR DESCRIPTION
Add methods to build oriented and non symmetric roadmap : 

* An optionnal argument to the nearest neighbor search, for pseudo metrics (non symmetric distance)

* Method addNodeAndEdge(Node from, Configuration to) and (Configuration from, Node to)  in roadmap to add a node and only one oriented edge.