### PR TITLE
Add derivative to abstract class Path

### DIFF
--- a/include/hpp/core/interpolated-path.hh
+++ b/include/hpp/core/interpolated-path.hh
@@ -197,7 +197,9 @@ namespace hpp {
 
       virtual bool impl_compute (ConfigurationOut_t result,
 				 value_type param) const;
-
+      /// Virtual implementation of derivative
+      virtual void impl_derivative (vectorOut_t result, const value_type& t,
+				    size_type order) const;
     private:
       DevicePtr_t device_;
       InterpolationPoints_t configs_;

--- a/include/hpp/core/path-vector.hh
+++ b/include/hpp/core/path-vector.hh
@@ -189,6 +189,9 @@ namespace hpp {
 	weak_ = self;
       }
       virtual bool impl_compute (ConfigurationOut_t result, value_type t) const;
+      /// Virtual implementation of derivative
+      virtual void impl_derivative (vectorOut_t result, const value_type& t,
+				    size_type order) const;
 
     private:
       Paths_t paths_;

--- a/include/hpp/core/path.hh
+++ b/include/hpp/core/path.hh
@@ -20,6 +20,7 @@
 # define HPP_CORE_PATH_HH
 
 # include <boost/concept_check.hpp>
+# include <hpp/util/exception.hh>
 # include <hpp/core/fwd.hh>
 # include <hpp/core/config.hh>
 # include <hpp/core/constraint-set.hh>
@@ -118,11 +119,34 @@ namespace hpp {
         return impl_compute (result, t);
       }
 
+      /// Get derivative with respect to parameter at given parameter
+      /// \param t value of the parameter in the definition interval,
+      /// \param order order of the derivative
+      /// \retval result derivative. Should be allocated and of correct size.
+      /// \warning the method is not implemented in this class and throws if
+      ///          called without being implemented in the derived class.
+      /// \note unless otherwise stated, this method is not compatible with
+      ///       constraints. The derivative of the non-constrained path will
+      ///       be computed.
+      void derivative (vectorOut_t result, const value_type& t, size_type order)
+	const
+      {
+	impl_derivative (result, t, order);
+      }
+
       /// \brief Function evaluation without applying constraints
       ///
       /// \return true if everything went good.
       virtual bool impl_compute (ConfigurationOut_t configuration,
 				 value_type t) const = 0;
+
+      /// Virtual implementation of derivative
+      virtual void impl_derivative (vectorOut_t, const value_type&,
+				    size_type) const
+      {
+	HPP_THROW_EXCEPTION (hpp::Exception, "not implemented");
+      }
+
       /// \name Constraints
       /// \{
 

--- a/include/hpp/core/reeds-shepp-path.hh
+++ b/include/hpp/core/reeds-shepp-path.hh
@@ -174,6 +174,9 @@ namespace hpp {
 
       virtual bool impl_compute (ConfigurationOut_t result,
 				 value_type param) const;
+      /// Virtual implementation of derivative
+      virtual void impl_derivative (vectorOut_t result, const value_type& t,
+				    size_type order) const;
 
     private:
       typedef Eigen::Matrix<value_type, 5, 1> Lengths_t;
@@ -200,6 +203,7 @@ namespace hpp {
       Configuration_t initial_;
       Configuration_t end_;
       const size_type xyId_,rzId_;
+      size_type dxyId_,drzId_;
       struct Wheels_t {
         value_type L, R, S; // Left, Right and Straight turn
         JointPtr_t j;

--- a/include/hpp/core/straight-path.hh
+++ b/include/hpp/core/straight-path.hh
@@ -206,6 +206,9 @@ namespace hpp {
 
       virtual bool impl_compute (ConfigurationOut_t result,
 				 value_type param) const;
+      /// Virtual implementation of derivative
+      virtual void impl_derivative (vectorOut_t result, const value_type& t,
+				    size_type order) const;
 
     private:
       DevicePtr_t device_;

--- a/src/extracted-path.hh
+++ b/src/extracted-path.hh
@@ -86,6 +86,18 @@ namespace hpp {
 	}
       }
 
+      virtual void impl_derivative (vectorOut_t result, const value_type& t,
+				    size_type order) const
+      {
+	if (reversed_) {
+	  value_type param = (timeRange ().first + timeRange ().second - t);
+	  original_->impl_derivative (result, param, order);
+	  if (order % 2 == 1) result *= -1.;
+	} else {
+	  original_->impl_derivative (result, t, order);
+	}
+      }
+
       virtual PathPtr_t extract (const interval_t& subInterval) const
         throw (projection_error)
       {

--- a/src/interpolated-path.cc
+++ b/src/interpolated-path.cc
@@ -126,6 +126,39 @@ namespace hpp {
       return true;
     }
 
+    void InterpolatedPath::impl_derivative
+    (vectorOut_t result, const value_type& t, size_type order) const
+    {
+      value_type param (t);
+      assert (param >= timeRange().first);
+      if (timeRange ().first == timeRange ().second) {
+	result.setZero ();
+	return;
+      }
+      if (param >= timeRange ().second) {
+	param = timeRange ().second;
+      }
+      InterpolationPoints_t::const_iterator itA = configs_.upper_bound (param);
+      InterpolationPoints_t::const_iterator itB = configs_.lower_bound (param);
+      if (itB == itA) {
+	if (itB == configs_.begin ()) {
+	  ++itA;
+	} else {
+	  --itB;
+	}
+      }
+      assert (itA != configs_.end ());
+      const value_type T = itA->first - itB->first;
+      if (order > 1) {
+	result.setZero ();
+	return;
+      }
+      if (order == 1) {
+	model::difference (device_, itA->second, itB->second, result);
+	result = (1/T) * result;
+      }
+    }
+
     PathPtr_t InterpolatedPath::extract (const interval_t& subInterval) const
         throw (projection_error)
     {

--- a/src/nearest-neighbor/k-d-tree.cc
+++ b/src/nearest-neighbor/k-d-tree.cc
@@ -237,7 +237,7 @@ namespace hpp {
 
     NodePtr_t KDTree::search (const ConfigurationPtr_t& configuration,
             const ConnectedComponentPtr_t& connectedComponent,
-                              value_type& minDistance, bool reverse) {
+                              value_type& minDistance, bool) {
       // Test if the configuration is in the root box
       for ( std::size_t i=0 ; i<dim_ ; i++ ) {
 	if ( (*configuration)[i] < lowerBounds_[i] || (*configuration)[i]

--- a/src/path-vector.cc
+++ b/src/path-vector.cc
@@ -114,6 +114,18 @@ namespace hpp {
       return (*subpath) (result, localParam);
     }
 
+    void PathVector::impl_derivative (vectorOut_t result, const value_type& t,
+				      size_type order) const
+    {
+      // Find direct path in vector corresponding to parameter.
+      size_t rank;
+      value_type localParam;
+      rank = rankAtParam (t, localParam);
+
+      PathPtr_t subpath = paths_ [rank];
+      subpath->impl_derivative (result, localParam, order);
+    }
+
     PathPtr_t PathVector::extract (const interval_t& subInterval) const
         throw (projection_error)
     {

--- a/src/path.cc
+++ b/src/path.cc
@@ -48,7 +48,7 @@ namespace hpp {
     // Copy constructor
     Path::Path (const Path& path) :
       timeRange_ (path.timeRange_), outputSize_ (path.outputSize_),
-      constraints_ ()
+      outputDerivativeSize_ (path.outputDerivativeSize_), constraints_ ()
     {
       if (path.constraints_) {
 	constraints_ = HPP_STATIC_PTR_CAST (ConstraintSet,
@@ -58,6 +58,7 @@ namespace hpp {
 
     Path::Path (const Path& path, const ConstraintSetPtr_t& constraints) :
       timeRange_ (path.timeRange_), outputSize_ (path.outputSize_),
+      outputDerivativeSize_ (path.outputDerivativeSize_),
       constraints_ (constraints)
     {
       assert (!path.constraints_);

--- a/src/random-shortcut.cc
+++ b/src/random-shortcut.cc
@@ -128,21 +128,21 @@ namespace hpp {
           if (valid [0])
             result->appendPath (proj [0]);
           else
-            result->concatenate (*(tmpPath->extract
-                  (make_pair <value_type,value_type> (t0, t1))->
-                  as <PathVector> ()));
+            result->concatenate (tmpPath->extract
+				 (make_pair <value_type,value_type> (t0, t1))->
+				 as <PathVector> ());
           if (valid [1])
             result->appendPath (proj [1]);
           else
-            result->concatenate (*(tmpPath->extract
-                  (make_pair <value_type,value_type> (t1, t2))->
-                  as <PathVector> ()));
+            result->concatenate (tmpPath->extract
+				 (make_pair <value_type,value_type> (t1, t2))->
+				 as <PathVector> ());
           if (valid [2])
             result->appendPath (proj [2]);
           else
-            result->concatenate (*(tmpPath->extract
-                  (make_pair <value_type, value_type> (t2, t3))->
-                  as <PathVector> ()));
+            result->concatenate (tmpPath->extract
+				 (make_pair <value_type, value_type> (t2, t3))->
+				 as <PathVector> ());
         } catch (const projection_error& e) {
           hppDout (error, "Caught exception at with time " << t1 << " and " <<
               t2 << ": " << e.what ());

--- a/src/straight-path.cc
+++ b/src/straight-path.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include <hpp/util/debug.hh>
+#include <hpp/util/exception.hh>
 #include <hpp/model/device.hh>
 #include <hpp/model/configuration.hh>
 #include <hpp/core/config-projector.hh>
@@ -84,6 +85,27 @@ namespace hpp {
 	u = 0;
       model::interpolate (device_, initial_, end_, u, result);
       return true;
+    }
+
+    void StraightPath::impl_derivative (vectorOut_t result, const value_type&,
+					size_type order) const
+    {
+      if (order > 1) {
+	result.setZero ();
+	return;
+      }
+      if (order == 1) {
+	if (timeRange ().first == timeRange ().second) {
+	  result.setZero ();
+	  return;
+	}
+	model::difference (device_, end_, initial_, result);
+	result = (1/timeRange ().second) * result;
+	return;
+      }
+      std::ostringstream oss;
+      oss << "order of derivative (" << order << ") should be positive.";
+      HPP_THROW_EXCEPTION (hpp::Exception, oss.str ());
     }
 
     PathPtr_t StraightPath::extract (const interval_t& subInterval) const


### PR DESCRIPTION
  - default implementation throws,
  - implemented in InterpolatedPath, PathVector, ReedsAndSheppPath,
    StraightPath, ExtractedPath.
  - does not take into account contraints.