### PR TITLE
SteeringMethod and Distance constructors take const Problem& instead …

### DIFF
--- a/include/hpp/core/distance/reeds-shepp.hh
+++ b/include/hpp/core/distance/reeds-shepp.hh
@@ -35,14 +35,14 @@ namespace hpp {
       {
       public:
 	virtual DistancePtr_t clone () const;
-	static ReedsSheppPtr_t create (const ProblemPtr_t& problem);
-	static ReedsSheppPtr_t create (const ProblemPtr_t& problem,
+	static ReedsSheppPtr_t create (const Problem& problem);
+	static ReedsSheppPtr_t create (const Problem& problem,
 				     const value_type& turningRadius,
 				     size_type xyRank, size_type rzRank);
 	static ReedsSheppPtr_t createCopy (const ReedsSheppPtr_t& distance);
       protected:
-	ReedsShepp (const ProblemPtr_t& problem);
-	ReedsShepp (const ProblemPtr_t& problem,
+	ReedsShepp (const Problem& problem);
+	ReedsShepp (const Problem& problem,
 		    const value_type& turningRadius,
 		    size_type xyRank, size_type rzRank);
 	ReedsShepp (const ReedsShepp& distance);

--- a/include/hpp/core/problem-solver.hh
+++ b/include/hpp/core/problem-solver.hh
@@ -48,9 +48,9 @@ namespace hpp {
       PathProjectorBuilder_t;
     typedef boost::function <ConfigurationShooterPtr_t (const DevicePtr_t&) >
       ConfigurationShooterBuilder_t;
-  typedef boost::function <DistancePtr_t (const ProblemPtr_t&) >
+  typedef boost::function <DistancePtr_t (const Problem&) >
     DistanceBuilder_t;
-    typedef boost::function <SteeringMethodPtr_t (const ProblemPtr_t&) >
+    typedef boost::function <SteeringMethodPtr_t (const Problem&) >
       SteeringMethodBuilder_t;
     typedef std::vector<CollisionObjectPtr_t > AffordanceObjects_t;
     typedef vector3_t AffordanceConfig_t;

--- a/include/hpp/core/steering-method-straight.hh
+++ b/include/hpp/core/steering-method-straight.hh
@@ -38,20 +38,9 @@ namespace hpp {
     {
     public:
       /// Create instance and return shared pointer
-      static SteeringMethodStraightPtr_t create (const ProblemPtr_t& problem)
+      static SteeringMethodStraightPtr_t create (const Problem& problem)
       {
 	SteeringMethodStraight* ptr = new SteeringMethodStraight (problem);
-	SteeringMethodStraightPtr_t shPtr (ptr);
-	ptr->init (shPtr);
-	return shPtr;
-      }
-      /// Create instance and return shared pointer
-      static SteeringMethodStraightPtr_t create
-	(const DevicePtr_t& device, const WeighedDistancePtr_t& distance)
-        HPP_CORE_DEPRECATED
-      {
-	SteeringMethodStraight* ptr = new SteeringMethodStraight (device,
-								  distance);
 	SteeringMethodStraightPtr_t shPtr (ptr);
 	ptr->init (shPtr);
 	return shPtr;
@@ -75,7 +64,7 @@ namespace hpp {
       virtual PathPtr_t impl_compute (ConfigurationIn_t q1,
 				      ConfigurationIn_t q2) const
       {
-        value_type length = (*problem_->distance()) (q1, q2);
+        value_type length = (*problem_.distance()) (q1, q2);
         ConstraintSetPtr_t c;
         if (constraints() && constraints()->configProjector ()) {
           c = HPP_STATIC_PTR_CAST (ConstraintSet, constraints()->copy ());
@@ -84,22 +73,15 @@ namespace hpp {
           c = constraints ();
         }
         PathPtr_t path = StraightPath::create
-          (problem_->robot(), q1, q2, length, c);
+          (problem_.robot(), q1, q2, length, c);
         return path;
       }
     protected:
       /// Constructor with robot
       /// Weighed distance is created from robot
-      SteeringMethodStraight (const ProblemPtr_t& problem) :
+      SteeringMethodStraight (const Problem& problem) :
 	SteeringMethod (problem), weak_ ()
       {
-      }
-      /// Constructor with weighed distance
-      SteeringMethodStraight (const DevicePtr_t& device,
-			      const WeighedDistancePtr_t& distance) :
-	SteeringMethod (new Problem (device)), weak_ ()
-      {
-        problem_->distance (distance);
       }
       /// Copy constructor
       SteeringMethodStraight (const SteeringMethodStraight& other) :

--- a/include/hpp/core/steering-method.hh
+++ b/include/hpp/core/steering-method.hh
@@ -75,7 +75,7 @@ namespace hpp {
 
     protected:
       /// Constructor
-      SteeringMethod (ProblemPtr_t problem) :
+      SteeringMethod (const Problem& problem) :
         problem_ (problem), constraints_ (), weak_ ()
       {
       }
@@ -99,7 +99,7 @@ namespace hpp {
 	weak_ = weak;
       }
 
-      ProblemPtr_t problem_;
+      const Problem& problem_;
 
     private:
       /// Set of constraints to apply on the paths produced

--- a/include/hpp/core/steering-method/reeds-shepp.hh
+++ b/include/hpp/core/steering-method/reeds-shepp.hh
@@ -45,7 +45,7 @@ namespace hpp {
           /// - the 2 following parameters corresponds to the RZ unbounded
           ///   rotation joint.
           /// Use ReedsShepp::setWheelJoints to set the wheel joints.
-          static ReedsSheppPtr_t createWithGuess (const ProblemPtr_t& problem)
+          static ReedsSheppPtr_t createWithGuess (const Problem& problem)
           {
             ReedsShepp* ptr = new ReedsShepp (problem);
             ReedsSheppPtr_t shPtr (ptr);
@@ -56,7 +56,7 @@ namespace hpp {
           /// Create an instance
           ///
           /// This constructor does no assumption.
-          static ReedsSheppPtr_t create (const ProblemPtr_t& problem,
+          static ReedsSheppPtr_t create (const Problem& problem,
               const value_type turningRadius,
               size_type xyRank, size_type rzRank,
               std::vector <JointPtr_t> wheels = std::vector<JointPtr_t>())
@@ -108,10 +108,10 @@ namespace hpp {
 
         protected:
           /// Constructor
-          ReedsShepp (const ProblemPtr_t& problem);
+          ReedsShepp (const Problem& problem);
 
           /// Constructor
-          ReedsShepp (const ProblemPtr_t& problem,
+          ReedsShepp (const Problem& problem,
               const value_type turningRadius,
               size_type xyRank, size_type rzRank,
               std::vector <JointPtr_t> wheels);

--- a/include/hpp/core/weighed-distance.hh
+++ b/include/hpp/core/weighed-distance.hh
@@ -33,7 +33,7 @@ namespace hpp {
     class HPP_CORE_DLLAPI WeighedDistance : public Distance {
     public:
       static WeighedDistancePtr_t createFromProblem
-	(const ProblemPtr_t& problem);
+	(const Problem& problem);
       static WeighedDistancePtr_t create (const DevicePtr_t& robot);
       static WeighedDistancePtr_t
     createWithWeight (const DevicePtr_t& robot,
@@ -59,7 +59,7 @@ namespace hpp {
 	return robot_;
       }
     protected:
-      WeighedDistance (const ProblemPtr_t& problem);
+      WeighedDistance (const Problem& problem);
       WeighedDistance (const DevicePtr_t& robot);
       WeighedDistance (const DevicePtr_t& robot,
 		       const std::vector <value_type>& weights);

--- a/src/distance/reeds-shepp.cc
+++ b/src/distance/reeds-shepp.cc
@@ -28,14 +28,14 @@ namespace hpp {
 	return createCopy (weak_.lock ());
       }
 
-      ReedsSheppPtr_t ReedsShepp::create (const ProblemPtr_t& problem)
+      ReedsSheppPtr_t ReedsShepp::create (const Problem& problem)
       {
 	ReedsShepp* ptr (new ReedsShepp (problem));
 	ReedsSheppPtr_t shPtr (ptr);
 	ptr->init (shPtr);
 	return shPtr;
       }
-      ReedsSheppPtr_t ReedsShepp::create (const ProblemPtr_t& problem,
+      ReedsSheppPtr_t ReedsShepp::create (const Problem& problem,
 					const value_type& turningRadius,
 					size_type xyRank, size_type rzRank)
       {
@@ -54,12 +54,12 @@ namespace hpp {
 	return shPtr;
       }
 
-      ReedsShepp::ReedsShepp (const ProblemPtr_t& problem) :
+      ReedsShepp::ReedsShepp (const Problem& problem) :
 	Distance (), sm_ (steeringMethod::ReedsShepp::createWithGuess (problem))
       {
       }
 
-      ReedsShepp::ReedsShepp (const ProblemPtr_t& problem,
+      ReedsShepp::ReedsShepp (const Problem& problem,
 			      const value_type& turningRadius,
 			      size_type xyRank, size_type rzRank) :
 	Distance (), sm_ (steeringMethod::ReedsShepp::create

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -161,7 +161,7 @@ namespace hpp {
       add <DistanceBuilder_t> ("WeighedDistance",
 			       WeighedDistance::createFromProblem);
       add <SteeringMethodBuilder_t> ("SteeringMethodStraight", boost::bind(
-            static_cast<SteeringMethodStraightPtr_t (*)(const ProblemPtr_t&)>
+            static_cast<SteeringMethodStraightPtr_t (*)(const Problem&)>
               (&SteeringMethodStraight::create), _1
             ));
       add <SteeringMethodBuilder_t> ("ReedsShepp", steeringMethod::ReedsShepp::createWithGuess);
@@ -542,7 +542,7 @@ namespace hpp {
     {
       if (!problem_) throw std::runtime_error ("The problem is not defined.");
       DistancePtr_t dist (
-          get <DistanceBuilder_t> (distanceType_) (problem_)
+          get <DistanceBuilder_t> (distanceType_) (*problem_)
           );
       problem_->distance (dist);
     }
@@ -552,7 +552,7 @@ namespace hpp {
     {
       if (!problem_) throw std::runtime_error ("The problem is not defined.");
       SteeringMethodPtr_t sm (
-          get <SteeringMethodBuilder_t> (steeringMethodType_) (problem_)
+          get <SteeringMethodBuilder_t> (steeringMethodType_) (*problem_)
           );
       problem_->steeringMethod (sm);
     }
@@ -568,7 +568,7 @@ namespace hpp {
       //       the problem constraints.
       PathProjectorPtr_t pathProjector_ =
         createProjector (problem_->distance (), 
-            SteeringMethodStraight::create (problem_),
+            SteeringMethodStraight::create (*problem_),
             pathProjectorTolerance_);
       problem_->pathProjector (pathProjector_);
     }
@@ -648,7 +648,7 @@ namespace hpp {
 
       // Create steering method using factory
       SteeringMethodPtr_t sm (get <SteeringMethodBuilder_t> 
-                             (steeringMethodType_) (problem_));
+                             (steeringMethodType_) (*problem_));
       problem_->steeringMethod (sm);
       PathPtr_t dp = (*sm) (start, end);
       if (!dp) {

--- a/src/problem.cc
+++ b/src/problem.cc
@@ -42,7 +42,7 @@ namespace hpp {
       robot_ (robot),
       distance_ (WeighedDistance::create (robot)),
       initConf_ (), goalConfigurations_ (), target_ (),
-      steeringMethod_ (SteeringMethodStraight::create (this)),
+      steeringMethod_ (SteeringMethodStraight::create (*this)),
       configValidations_ (),
       pathValidation_ (DiscretizedCollisionChecking::create
 		       (robot, 0.05)),

--- a/src/steering-method/reeds-shepp.cc
+++ b/src/steering-method/reeds-shepp.cc
@@ -49,8 +49,8 @@ namespace hpp {
         hppDout (info, "rho_ = " << rho_);
       }
 
-      ReedsShepp::ReedsShepp (const ProblemPtr_t& problem) :
-        SteeringMethod (problem), device_ (problem->robot ()),
+      ReedsShepp::ReedsShepp (const Problem& problem) :
+        SteeringMethod (problem), device_ (problem.robot ()),
         rho_ (1.), xy_ (0), rz_(2), weak_ ()
       {
         DevicePtr_t d (device_.lock());
@@ -73,13 +73,13 @@ namespace hpp {
         computeRadius();
       }
 
-      ReedsShepp::ReedsShepp (const ProblemPtr_t& problem,
+      ReedsShepp::ReedsShepp (const Problem& problem,
           const value_type turningRadius,
           size_type xyRank, size_type rzRank,
           std::vector <JointPtr_t> wheels) :
-        SteeringMethod (problem), device_ (problem->robot ()),
+        SteeringMethod (problem), device_ (problem.robot ()),
         rho_ (turningRadius),
-        turningJoint_ (problem->robot ()->getJointAtConfigRank (rzRank)),
+        turningJoint_ (problem.robot ()->getJointAtConfigRank (rzRank)),
         xy_ (xyRank),
         rz_ (rzRank),
         wheels_ (wheels), weak_ ()

--- a/src/weighed-distance.cc
+++ b/src/weighed-distance.cc
@@ -196,7 +196,7 @@ namespace hpp {
     }
 
     WeighedDistancePtr_t WeighedDistance::createFromProblem
-    (const ProblemPtr_t& problem)
+    (const Problem& problem)
     {
       WeighedDistance* ptr = new WeighedDistance (problem);
       WeighedDistancePtr_t shPtr (ptr);
@@ -284,8 +284,8 @@ namespace hpp {
       computeWeights ();
     }
 
-    WeighedDistance::WeighedDistance (const ProblemPtr_t& problem) :
-      robot_ (problem->robot()), weights_ ()
+    WeighedDistance::WeighedDistance (const Problem& problem) :
+      robot_ (problem.robot()), weights_ ()
     {
       computeWeights ();
     }

--- a/tests/roadmap-1.cc
+++ b/tests/roadmap-1.cc
@@ -110,8 +110,8 @@ BOOST_AUTO_TEST_CASE (Roadmap1) {
   robot->createGeomData();
 
   // Create steering method
-  Problem p = Problem (robot);
-  SteeringMethodStraightPtr_t sm = SteeringMethodStraight::create (&p);
+  Problem p (robot);
+  SteeringMethodStraightPtr_t sm = SteeringMethodStraight::create (p);
   // create roadmap
   hpp::core::DistancePtr_t distance (WeighedDistance::createWithWeight
 				     (robot, boost::assign::list_of (1)(1)));
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE (nearestNeighbor) {
 
   // Create steering method
   Problem p (robot);
-  SteeringMethodStraightPtr_t sm = SteeringMethodStraight::create (&p);
+  SteeringMethodStraightPtr_t sm = SteeringMethodStraight::create (p);
   // create roadmap
   hpp::core::DistancePtr_t distance (WeighedDistance::createWithWeight
 				     (robot, boost::assign::list_of (1)(1)));

--- a/tests/test-continuous-collision-checking.cc
+++ b/tests/test-continuous-collision-checking.cc
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE (continuous_collision_checking)
   ConfigurationShooterPtr_t shooter (BasicConfigurationShooter::create (robot));
 
   // create steering method
-  ProblemPtr_t problem (new Problem (robot));
+  Problem problem (robot);
   SteeringMethodPtr_t sm (SteeringMethodStraight::create (problem));
 
   // create path validation objects
@@ -154,7 +154,6 @@ BOOST_AUTO_TEST_CASE (continuous_collision_checking)
     }
   }
   // delete problem
-  delete problem;
 }
 
 


### PR DESCRIPTION
…of ProblemPtr_t

This homogenizes the API. The downside is that dependencies may need to be updated.