### PR TITLE
Allow a problem to have no goal configuration

### DIFF
--- a/src/problem-target/goal-configurations.cc
+++ b/src/problem-target/goal-configurations.cc
@@ -41,12 +41,6 @@ namespace hpp {
 
       void GoalConfigurations::check (const RoadmapPtr_t& roadmap) const
       {
-        const NodeVector_t& goals = roadmap->goalNodes();
-        if (goals.empty ()) {
-          std::string msg ("No goal configurations.");
-          hppDout (error, msg);
-          throw std::runtime_error (msg);
-        }
       }
 
       bool GoalConfigurations::reached (const RoadmapPtr_t& roadmap) const


### PR DESCRIPTION
  - this enables users to build a roadmap without specifying a problem.