### PR TITLE
Fix broken build due to missing headers.

### DIFF
--- a/tests/explicit-relative-transformation.cc
+++ b/tests/explicit-relative-transformation.cc
@@ -28,6 +28,8 @@
 #include <hpp/core/fwd.hh>
 #include <hpp/constraints/explicit/relative-pose.hh>
 #include <hpp/constraints/matrix-view.hh>
+#include <hpp/constraints/differentiable-function.hh>
+#include <hpp/constraints/generic-transformation.hh>
 
 #include <pinocchio/spatial/skew.hpp>
 #include <pinocchio/algorithm/joint-configuration.hpp>


### PR DESCRIPTION
The unit test explicit-relative-transformation breaks the build on my side due to the use of only forward declared types (missing headers).