### PR TITLE
fix build with recent boost version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,10 +23,6 @@ cache:
     - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
     - make test
 
-robotpkg-hpp-core-14.04-release:
-  <<: *robotpkg-hpp-core
-  image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-core/hpp-core:14.04
-
 robotpkg-hpp-core-16.04-release:
   <<: *robotpkg-hpp-core
   image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-core/hpp-core:16.04
@@ -53,4 +49,3 @@ doc-coverage:
     paths:
       - doxygen-html/
       - coverage/
-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,56 @@
+# Please don't edit this file, and use the version generated at
+# http://rainboard.laas.fr/project/hpp-core/.gitlab-ci.yml
+
+variables:
+  GIT_SUBMODULE_STRATEGY: "recursive"
+  CCACHE_BASEDIR: "${CI_PROJECT_DIR}"
+  CCACHE_DIR: "${CI_PROJECT_DIR}/ccache"
+
+cache:
+  paths:
+    - ccache
+
+.robotpkg-hpp-core: &robotpkg-hpp-core
+  except:
+    - gh-pages
+  script:
+    - mkdir -p ccache
+    - cd /root/robotpkg/path
+    - git pull
+    - cd hpp-core
+    - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
+    - make install
+    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
+    - make test
+
+robotpkg-hpp-core-14.04-release:
+  <<: *robotpkg-hpp-core
+  image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-core/hpp-core:14.04
+
+robotpkg-hpp-core-16.04-release:
+  <<: *robotpkg-hpp-core
+  image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-core/hpp-core:16.04
+
+robotpkg-hpp-core-18.04-release:
+  <<: *robotpkg-hpp-core
+  image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-core/hpp-core:18.04
+
+doc-coverage:
+  <<: *robotpkg-hpp-core
+  image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-core/hpp-core:16.04
+  before_script:
+    - echo -e 'CXXFLAGS+= --coverage\nLDFLAGS+= --coverage\nPKG_DEFAULT_OPTIONS= debug' >> /opt/openrobots/etc/robotpkg.conf
+  after_script:
+    - cd /root/robotpkg/path/hpp-core
+    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
+    - make doc
+    - mv doc/doxygen-html ${CI_PROJECT_DIR}
+    - mkdir -p ${CI_PROJECT_DIR}/coverage/
+    - gcovr -r .
+    - gcovr -r . --html --html-details -o ${CI_PROJECT_DIR}/coverage/index.html
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - doxygen-html/
+      - coverage/
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# HPP-core
+
+[![Building Status](https://travis-ci.org/humanoid-path-planner/hpp-core.svg?branch=master)](https://travis-ci.org/humanoid-path-planner/hpp-core)
+[![Pipeline status](https://gepgitlab.laas.fr/humanoid-path-planner/hpp-core/badges/master/pipeline.svg)](https://gepgitlab.laas.fr/humanoid-path-planner/hpp-core/commits/master)
+[![Coverage report](https://gepgitlab.laas.fr/humanoid-path-planner/hpp-core/badges/master/coverage.svg?job=doc-coverage)](http://projects.laas.fr/gepetto/doc/humanoid-path-planner/hpp-core/master/coverage/)
+
 This package implements path planning algorithms for kinematic chains.
 Kinematic chains are represented by class hpp::pinocchio::Device.
 

--- a/src/weighed-distance.cc
+++ b/src/weighed-distance.cc
@@ -144,7 +144,7 @@ namespace hpp {
       {
         typedef boost::fusion::vector<ConfigurationIn_t,
                 ConfigurationIn_t,
-                const value_type,
+                const value_type &,
                 value_type &> ArgsType;
 
         JOINT_MODEL_VISITOR_INIT(SquaredDistanceStep);


### PR DESCRIPTION
Hi,

This PR mainly use a const ref in a `boost::fusion::vector`, to fix build in recent boost versions.
Cf. https://github.com/stack-of-tasks/pinocchio/issues/511

It also add CI, but not for 14.04.
Right now, the tests are not passing, so this raises #128