### PR TITLE
Fix test test-config-validations

### DIFF
--- a/include/hpp/core/continuous-validation.hh
+++ b/include/hpp/core/continuous-validation.hh
@@ -140,11 +140,11 @@ namespace hpp {
         bool reverse, PathPtr_t& validPart, PathValidationReportPtr_t& report) = 0;
 
       template<typename IntervalValidations, typename ValidationReportTypePtr_t>
-      bool validateIntervals(IntervalValidations& validations, const value_type &t,
-                    interval_t &interval, interval_t &tmpInt,
-                    PathValidationReportPtr_t &pathReport,
-                    typename IntervalValidations::iterator &smallestInterval,
-                    pinocchio::DeviceData& data)
+      bool validateIntervals
+        (IntervalValidations& validations, const value_type &t,
+         interval_t &interval, PathValidationReportPtr_t &pathReport,
+         typename IntervalValidations::iterator& smallestInterval,
+         pinocchio::DeviceData& data)
       {
         typename IntervalValidations::iterator itMin = validations.begin();
         for (typename IntervalValidations::iterator itVal = validations.begin();
@@ -153,7 +153,7 @@ namespace hpp {
           ValidationReportTypePtr_t report;
           // the valid interval will not be greater than "interval" so we do not
           // need to perform validation on a greater interval.
-          tmpInt = interval;
+          interval_t tmpInt = interval;
           if (!(*itVal)->validateConfiguration(t, tmpInt, report, data))
           {
             pathReport = PathValidationReportPtr_t(new PathValidationReport);

--- a/include/hpp/core/continuous-validation.hh
+++ b/include/hpp/core/continuous-validation.hh
@@ -139,6 +139,18 @@ namespace hpp {
       virtual bool validateStraightPath (const PathPtr_t& path,
         bool reverse, PathPtr_t& validPart, PathValidationReportPtr_t& report) = 0;
 
+      /// Validate a set of intervals for a given parameter along a path
+      ///
+      /// \tparam IntervalValidations type of container of validation elements
+      ///         (for instance validation for collision between a pair of
+      ///         bodies),
+      /// \tparam ValidationReportTypePtr_t type of validation report produced
+      ///         in case non validation. Should derive from ValidationReport.
+      /// \param objects able to validate an interval for collision,
+      /// \param t center of the interval to be validated,
+      /// \retval interval interval validated for all objects,
+      /// \retval smallestInterval iterator to the validation element that
+      ///         returned the smallest interval.
       template<typename IntervalValidations, typename ValidationReportTypePtr_t>
       bool validateIntervals
         (IntervalValidations& validations, const value_type &t,

--- a/src/continuous-validation.cc
+++ b/src/continuous-validation.cc
@@ -35,10 +35,9 @@ namespace hpp {
 
     /// Validate interval centered on a path parameter
     /// \param config Configuration at abscissa tmin on the path.
-    /// \param tmin parameter value in the path interval of definition
-    /// \retval tmin lower bound of valid interval if reverve is true,
-    ///              upper bound of valid interval if reverse is false.
-    ///              other bound of valid interval is input tmin.
+    /// \param t parameter value in the path interval of definition
+    /// \retval interval interval validated for all validation elements
+    /// \retval report reason why the interval is not valid,
     /// \return true if the configuration is collision free for this parameter
     ///         value, false otherwise.
     bool ContinuousValidation::validateConfiguration(const Configuration_t &config, const value_type &t,

--- a/src/continuous-validation.cc
+++ b/src/continuous-validation.cc
@@ -46,14 +46,13 @@ namespace hpp {
     {
       interval.first = -std::numeric_limits <value_type>::infinity ();
       interval.second = std::numeric_limits <value_type>::infinity ();
-      interval_t tmpInt;
       pinocchio::DeviceSync robot (robot_);
       robot.currentConfiguration (config);
       robot.computeForwardKinematics();
       robot.updateGeometryPlacements();
       BodyPairCollisions_t::iterator smallestInterval = bodyPairCollisions_.begin();
       if (!validateIntervals<BodyPairCollisions_t, CollisionValidationReportPtr_t>
-            (bodyPairCollisions_, t, interval, tmpInt, report,
+            (bodyPairCollisions_, t, interval, report,
              smallestInterval, robot.d()))
         return false;
       // Put the smallest interval first so that, at next iteration,

--- a/src/continuous-validation/body-pair-collision.cc
+++ b/src/continuous-validation/body-pair-collision.cc
@@ -148,8 +148,8 @@ namespace hpp {
       {
         using std::numeric_limits;
         distanceLowerBound = numeric_limits <value_type>::infinity ();
-        static const fcl::CollisionRequest request (1, false, true, 1, false,
-          true, fcl::GST_INDEP);
+        static const fcl::CollisionRequest request (false, 1, true);
+        assert (request.enable_distance_lower_bound == true);
         for (CollisionPairs_t::const_iterator _pair = pairs_.begin();
             _pair != pairs_.end(); ++_pair) {
           pinocchio::FclConstCollisionObjectPtr_t object_a = _pair->first ->fcl (data);

--- a/src/continuous-validation/body-pair-collision.cc
+++ b/src/continuous-validation/body-pair-collision.cc
@@ -42,6 +42,7 @@ namespace hpp {
 
         if (valid_) {
           interval = path_->timeRange ();
+          assert (interval.second > interval.first);
           return true;
         }
         continuous_interval iclInterval (interval.first, interval.second,
@@ -50,6 +51,7 @@ namespace hpp {
         {
           // TODO interval could probably be enlarge using validInterval_
           // interval = validInterval_;
+          assert (interval.second > interval.first);
           return true;
         }
 
@@ -86,6 +88,7 @@ namespace hpp {
           path_->timeRange ().second, icl::interval_bounds::closed());
         if (icl::contains (validInterval_, iclInterval))
           valid_ = true;
+        assert (interval.second > interval.first);
         return true;
       }
 

--- a/src/continuous-validation/body-pair-collision.cc
+++ b/src/continuous-validation/body-pair-collision.cc
@@ -163,6 +163,7 @@ namespace hpp {
           }
           if (result.distance_lower_bound < distanceLowerBound) {
             distanceLowerBound = result.distance_lower_bound;
+            assert (distanceLowerBound > 0);
           }
         }
         return true;

--- a/src/path-optimization/spline-gradient-based/collision-constraint.hh
+++ b/src/path-optimization/spline-gradient-based/collision-constraint.hh
@@ -122,7 +122,7 @@ namespace hpp {
 	 robot_->computeForwardKinematics ();
          robot_->updateGeometryPlacements ();
 	 fcl::CollisionResult result;
-         fcl::CollisionRequest collisionRequest (1, enableContact, false, 1, false, true, fcl::GST_INDEP);
+         fcl::CollisionRequest collisionRequest (enableContact, 1, false);
          fcl::collide (object1_->fcl (), object2_->fcl (), collisionRequest, result);
          return result;
        }

--- a/tests/test-config-validations.cc
+++ b/tests/test-config-validations.cc
@@ -49,13 +49,14 @@ BOOST_AUTO_TEST_CASE ( test_add_config_validation )
     ProblemSolverPtr_t ps = ProblemSolver::create ();
     ps->robot ( ps->createRobot ("robot") );
     ProblemPtr_t problem = ps->problem ();
-    ConfigValidationsPtr_t configValidations = problem->configValidations ();
 
     ps->clearConfigValidations ();
-    BOOST_CHECK_MESSAGE (configValidations->numberConfigValidations () == 0,
-        "Clearing ConfigValidations did not work");
+    BOOST_CHECK_MESSAGE
+      (problem->configValidations ()->numberConfigValidations () == 0,
+       "Clearing ConfigValidations did not work");
 
     ps->addConfigValidation ("CollisionValidation");
-    BOOST_CHECK_MESSAGE (configValidations->numberConfigValidations () == 1,
-        "Adding CollisionValidation to the ProblemSolver did not work");
+    BOOST_CHECK_MESSAGE
+      (problem->configValidations ()->numberConfigValidations () == 1,
+       "Adding CollisionValidation to the ProblemSolver did not work");
 }


### PR DESCRIPTION
Since commit 60f1ff33, test-config-validations is broken since
problem->configValidations is reinitialized. This PR fixes this issue (#142).

Note that there are also some other minor modifications.