### PR TITLE
[Refactoring] Remove usage of ConfigurationPtr_t + Add methods equivalent to operator()

### DIFF
--- a/include/hpp/core/bi-rrt-planner.hh
+++ b/include/hpp/core/bi-rrt-planner.hh
@@ -49,7 +49,7 @@ namespace hpp {
       /// Store weak pointer to itself
       void init (const BiRRTPlannerWkPtr_t& weak);
       PathPtr_t extendInternal (const SteeringMethodPtr_t& sm, Configuration_t& qProj_, const NodePtr_t& near,
-                      const ConfigurationPtr_t& target, bool reverse=false);
+                      const Configuration_t& target, bool reverse=false);
 
       ConfigurationShooterPtr_t configurationShooter_;
       ConnectedComponentPtr_t startComponent_;

--- a/include/hpp/core/configuration-shooter.hh
+++ b/include/hpp/core/configuration-shooter.hh
@@ -35,7 +35,16 @@ namespace hpp {
     {
     public:
       /// Shoot a random configuration
-      virtual ConfigurationPtr_t shoot () const = 0;
+      virtual ConfigurationPtr_t shoot () const
+      {
+        ConfigurationPtr_t q (new Configuration_t);
+        shoot (*q);
+        return q;
+      }
+
+      /// Shoot a random configuration
+      /// \param q the configuration (resized if necessary).
+      virtual void shoot (Configuration_t& q) const = 0;
 
       virtual ~ConfigurationShooter () {};
     protected:

--- a/include/hpp/core/configuration-shooter/gaussian.hh
+++ b/include/hpp/core/configuration-shooter/gaussian.hh
@@ -44,7 +44,7 @@ namespace hpp {
             ptr->init (shPtr);
             return shPtr;
           }
-          virtual ConfigurationPtr_t shoot () const;
+          virtual void shoot (Configuration_t& q) const;
 
           void center (ConfigurationIn_t c)
           {

--- a/include/hpp/core/configuration-shooter/uniform.hh
+++ b/include/hpp/core/configuration-shooter/uniform.hh
@@ -42,7 +42,7 @@ namespace hpp {
           ptr->init (shPtr);
           return shPtr;
         }
-        virtual ConfigurationPtr_t shoot () const;
+        virtual void shoot (Configuration_t& q) const;
 
         void sampleExtraDOF(bool sampleExtraDOF){
             sampleExtraDOF_=sampleExtraDOF;

--- a/include/hpp/core/diffusing-planner.hh
+++ b/include/hpp/core/diffusing-planner.hh
@@ -50,7 +50,7 @@ namespace hpp {
       /// \param near node in the roadmap,
       /// \param target target configuration
       virtual PathPtr_t extend (const NodePtr_t& near,
-				const ConfigurationPtr_t& target);
+				const Configuration_t& target);
     private:
       ConfigurationShooterPtr_t configurationShooter_;
       mutable Configuration_t qProj_;

--- a/include/hpp/core/distance.hh
+++ b/include/hpp/core/distance.hh
@@ -43,6 +43,17 @@ namespace hpp {
 	return impl_distance (n1, n2);
       }
 
+      value_type compute (ConfigurationIn_t q1,
+				  ConfigurationIn_t q2) const
+      {
+	return impl_distance (q1, q2);
+      }
+
+      value_type compute (NodePtr_t n1, NodePtr_t n2) const
+      {
+	return impl_distance (n1, n2);
+      }
+
       virtual DistancePtr_t clone () const = 0;
 
       virtual ~Distance () {};

--- a/include/hpp/core/nearest-neighbor.hh
+++ b/include/hpp/core/nearest-neighbor.hh
@@ -39,7 +39,7 @@ namespace hpp {
        *  if false from nodes in roadmap to given configuration
        * @return
        */
-      virtual NodePtr_t search (const ConfigurationPtr_t& configuration,
+      virtual NodePtr_t search (const Configuration_t& configuration,
 			       const ConnectedComponentPtr_t&
 				connectedComponent,
              value_type& distance,bool reverse = false) = 0;
@@ -52,7 +52,7 @@ namespace hpp {
 
       /// \param[out] distance to the Kth closest neighbor
       /// \return the K nearest neighbors
-      virtual Nodes_t KnearestSearch (const ConfigurationPtr_t& configuration,
+      virtual Nodes_t KnearestSearch (const Configuration_t& configuration,
 			              const ConnectedComponentPtr_t&
                                         connectedComponent,
                                       const std::size_t K,
@@ -71,7 +71,7 @@ namespace hpp {
       /// \param K the number of nearest neighbors to return
       /// \retval distance to the Kth closest neighbor
       /// \return the K nearest neighbors
-      virtual Nodes_t KnearestSearch (const ConfigurationPtr_t& configuration,
+      virtual Nodes_t KnearestSearch (const Configuration_t& configuration,
                                       const RoadmapPtr_t& roadmap,
                                       const std::size_t K,
 			              value_type& distance) = 0;

--- a/include/hpp/core/path.hh
+++ b/include/hpp/core/path.hh
@@ -141,6 +141,17 @@ namespace hpp {
         return applyConstraints (result, s);
       }
 
+      Configuration_t eval (const value_type& time, bool& success) const
+      {
+        return this->operator() (time, success);
+      }
+
+      bool eval (ConfigurationOut_t result, const value_type& time)
+       const throw ()
+      {
+        return this->operator() (result, time);
+      }
+
       /// Get the configuration at a parameter without applying the constraints.
       bool at (const value_type& time, ConfigurationOut_t result) const
       {

--- a/include/hpp/core/roadmap.hh
+++ b/include/hpp/core/roadmap.hh
@@ -48,13 +48,24 @@ namespace hpp {
       /// connected component with this node.
       NodePtr_t addNode (const ConfigurationPtr_t& config);
 
+      NodePtr_t addNode (const Configuration_t& config)
+      {
+        return addNode (ConfigurationPtr_t (new Configuration_t(config)));
+      }
+
       /// Get nearest node to a configuration in the roadmap.
       /// \param configuration configuration
       /// \param reverse if true, compute distance from given configuration to nodes in roadmap,
       /// if false from nodes in roadmap to given configuration
       /// \retval distance to the nearest node.
-      NodePtr_t nearestNode (const ConfigurationPtr_t& configuration,
+      NodePtr_t nearestNode (const Configuration_t& configuration,
            value_type& minDistance, bool reverse = false);
+
+      NodePtr_t nearestNode (const ConfigurationPtr_t& configuration,
+           value_type& minDistance, bool reverse = false)
+      {
+        return nearestNode (*configuration, minDistance, reverse);
+      }
 
       /// Get nearest node to a configuration in a connected component.
       /// \param configuration configuration
@@ -62,17 +73,30 @@ namespace hpp {
       /// \param reverse if true, compute distance from given configuration to nodes in roadmap,
       /// if false from nodes in roadmap to given configuration
       /// \retval distance to the nearest node.
-      NodePtr_t nearestNode (const ConfigurationPtr_t& configuration,
+      NodePtr_t nearestNode (const Configuration_t& configuration,
 			     const ConnectedComponentPtr_t& connectedComponent,
            value_type& minDistance, bool reverse = false);
+
+      NodePtr_t nearestNode (const ConfigurationPtr_t& configuration,
+			     const ConnectedComponentPtr_t& connectedComponent,
+           value_type& minDistance, bool reverse = false)
+      {
+        return nearestNode (*configuration, connectedComponent, minDistance, reverse);
+      }
 
       /// Get nearest node to a configuration in the roadmap.
       /// \param configuration configuration
       /// \param k number of nearest nodes to return
       /// if false from nodes in roadmap to given configuration
       /// \return k nearest nodes
-      Nodes_t nearestNodes (const ConfigurationPtr_t& configuration,
+      Nodes_t nearestNodes (const Configuration_t& configuration,
                             size_type k);
+
+      Nodes_t nearestNodes (const ConfigurationPtr_t& configuration,
+                            size_type k)
+      {
+        return nearestNodes (*configuration, k);
+      }
 
       /// Get nearest node to a configuration in a connected component.
       /// \param configuration configuration
@@ -80,10 +104,18 @@ namespace hpp {
       /// \param k number of nearest nodes to return
       /// if false from nodes in roadmap to given configuration
       /// \return k nearest nodes in the connected component
-      Nodes_t nearestNodes (const ConfigurationPtr_t& configuration,
+      Nodes_t nearestNodes (const Configuration_t& configuration,
                             const ConnectedComponentPtr_t&
                             connectedComponent,
                             size_type k);
+
+      Nodes_t nearestNodes (const ConfigurationPtr_t& configuration,
+                            const ConnectedComponentPtr_t&
+                            connectedComponent,
+                            size_type k)
+      {
+        return nearestNodes (*configuration, connectedComponent, k);
+      }
 
       /// Add a node and two edges
       /// \param from node from which the edge starts,

--- a/include/hpp/core/steering-method.hh
+++ b/include/hpp/core/steering-method.hh
@@ -52,6 +52,12 @@ namespace hpp {
 	return PathPtr_t ();
       }
 
+      /// \copydoc SteeringMethod::operator()(ConfigurationIn_t,ConfigurationIn_t)
+      PathPtr_t steer (ConfigurationIn_t q1, ConfigurationIn_t q2) const
+      {
+        return this->operator() (q1, q2);
+      }
+
       virtual ~SteeringMethod () {};
 
       /// Copy instance and return shared pointer

--- a/include/hpp/core/visibility-prm-planner.hh
+++ b/include/hpp/core/visibility-prm-planner.hh
@@ -58,13 +58,16 @@ namespace hpp {
 
       /// Return true if the configuration is visible from the given 
       /// connected component.
-      bool visibleFromCC (const ConfigurationPtr_t q, 
+      bool visibleFromCC (const Configuration_t q, 
 			  const ConnectedComponentPtr_t cc);
       
       /// Apply the problem constraints on a given configuration qTo by 
       /// projecting it on the tangent space of qFrom.
-      ConfigurationPtr_t applyConstraints (const ConfigurationPtr_t qFrom, 
-					   const ConfigurationPtr_t qTo);
+      void applyConstraints (
+          const Configuration_t& qFrom, 
+          const Configuration_t& qTo,
+          Configuration_t& qOut);
+
       bool constrApply_; // True if applyConstraints has successed
     };
     /// \}

--- a/src/bi-rrt-planner.cc
+++ b/src/bi-rrt-planner.cc
@@ -69,7 +69,7 @@ namespace hpp {
     }
 
     PathPtr_t BiRRTPlanner::extendInternal (const SteeringMethodPtr_t& sm, Configuration_t& qProj_, const NodePtr_t& near,
-                    const ConfigurationPtr_t& target, bool reverse)
+                    const Configuration_t& target, bool reverse)
     {
         const ConstraintSetPtr_t& constraints (sm->constraints ());
         if (constraints)
@@ -77,12 +77,12 @@ namespace hpp {
             ConfigProjectorPtr_t configProjector (constraints->configProjector ());
             if (configProjector)
             {
-                configProjector->projectOnKernel (*(near->configuration ()), *target,
+                configProjector->projectOnKernel (*(near->configuration ()), target,
                         qProj_);
             }
             else
             {
-                qProj_ = *target;
+                qProj_ = target;
             }
             if (constraints->apply (qProj_))
             {
@@ -93,7 +93,7 @@ namespace hpp {
                 return PathPtr_t ();
             }
         }
-        return reverse ? (*sm) (*target, *(near->configuration ())) : (*sm) (*(near->configuration ()), *target);
+        return reverse ? (*sm) (target, *(near->configuration ())) : (*sm) (*(near->configuration ()), target);
     }
 
 
@@ -118,7 +118,8 @@ namespace hpp {
         bool startComponentConnected(false), pathValidFromStart(false);
         ConfigurationPtr_t q_new;
         // first try to connect to start component
-        ConfigurationPtr_t q_rand = configurationShooter_->shoot ();
+        Configuration_t q_rand;
+        configurationShooter_->shoot (q_rand);
         near = roadmap()->nearestNode (q_rand, startComponent_, distance);
         path = extendInternal (problem().steeringMethod(), qProj_, near, q_rand);
         if (path)

--- a/src/configuration-shooter/gaussian.cc
+++ b/src/configuration-shooter/gaussian.cc
@@ -106,7 +106,7 @@ namespace hpp {
         ::pinocchio::details::Dispatch<ComputeSigmasStep>::run(jmodel.derived(), ComputeSigmasStep::ArgsType(model, sigmas));
       }
 
-      ConfigurationPtr_t Gaussian::shoot () const
+      void Gaussian::shoot (Configuration_t& config) const
       {
         static boost::random::mt19937 eng;
         vector_t velocity (robot_->numberDof());
@@ -116,11 +116,9 @@ namespace hpp {
           velocity[i] = distrib (eng);
         }
 
-        ConfigurationPtr_t config(new Configuration_t(robot_->configSize ()));
-        ::hpp::pinocchio::integrate (robot_, center_, velocity, *config);
-        ::hpp::pinocchio::saturate  (robot_, *config);
-
-        return config;
+        config.resize(robot_->configSize ());
+        ::hpp::pinocchio::integrate (robot_, center_, velocity, config);
+        ::hpp::pinocchio::saturate  (robot_, config);
       }
 
       void Gaussian::sigma(const value_type& factor)

--- a/src/configuration-shooter/uniform.cc
+++ b/src/configuration-shooter/uniform.cc
@@ -26,12 +26,12 @@ namespace hpp {
   namespace core {
     namespace configurationShooter {
 
-      ConfigurationPtr_t Uniform::shoot () const
+      void Uniform::shoot (Configuration_t& config) const
       {
         size_type extraDim = robot_->extraConfigSpace ().dimension ();
         size_type offset = robot_->configSize () - extraDim;
 
-        Configuration_t config(robot_->configSize ());
+        config.resize(robot_->configSize ());
         config.head (offset) = ::pinocchio::randomConfiguration(robot_->model());
 
         if(sampleExtraDOF_){
@@ -52,7 +52,6 @@ namespace hpp {
         }else{
             config.tail(extraDim).setZero();
         }
-        return boost::make_shared<Configuration_t> (config);
       }
 
     } // namespace configurationShooter

--- a/src/diffusing-planner.cc
+++ b/src/diffusing-planner.cc
@@ -93,26 +93,26 @@ namespace hpp {
     }
 
     PathPtr_t DiffusingPlanner::extend (const NodePtr_t& near,
-					const ConfigurationPtr_t& target)
+					const Configuration_t& target)
     {
       const SteeringMethodPtr_t& sm (problem ().steeringMethod ());
       const ConstraintSetPtr_t& constraints (sm->constraints ());
       if (constraints) {
 	ConfigProjectorPtr_t configProjector (constraints->configProjector ());
 	if (configProjector) {
-	  configProjector->projectOnKernel (*(near->configuration ()), *target,
+	  configProjector->projectOnKernel (*(near->configuration ()), target,
 					    qProj_);
 	} else {
-	  qProj_ = *target;
+	  qProj_ = target;
 	}
 	if (!constraints->apply (qProj_)) {
 	  return PathPtr_t ();
 	}
       } else {
-        qProj_ = *target;
+        qProj_ = target;
       }
       // Here, qProj_ is a configuration that satisfies the constraints
-      // or *target if there are no constraints.
+      // or target if there are no constraints.
       PathPtr_t path = (*sm) (*(near->configuration ()), qProj_);
       PathProjectorPtr_t pp = problem ().pathProjector();
       if (pp) {
@@ -161,7 +161,8 @@ namespace hpp {
       Nodes_t newNodes, nearestNeighbors;
       PathPtr_t validPath, path;
       // Pick a random node
-      ConfigurationPtr_t q_rand = configurationShooter_->shoot ();
+      Configuration_t q_rand;
+      configurationShooter_->shoot (q_rand);
       //
       // First extend each connected component toward q_rand
       //

--- a/src/nearest-neighbor/basic.cc
+++ b/src/nearest-neighbor/basic.cc
@@ -39,7 +39,7 @@ namespace hpp {
                 DistAndNodeComp_t > Queue_t;
       }
 
-      NodePtr_t Basic::search (const ConfigurationPtr_t& configuration,
+      NodePtr_t Basic::search (const Configuration_t& configuration,
              const ConnectedComponentPtr_t&
         connectedComponent,
              value_type& distance, bool reverse)
@@ -52,9 +52,9 @@ namespace hpp {
 	       connectedComponent->nodes ().begin ();
 	     itNode != connectedComponent->nodes ().end (); ++itNode) {
     if(reverse)
-      d = dist ( *configuration, *(*itNode)->configuration ());
+      d = dist ( configuration, *(*itNode)->configuration ());
     else
-      d = dist ( *(*itNode)->configuration (), *configuration);
+      d = dist ( *(*itNode)->configuration (), configuration);
 	  if (d < distance) {
 	    distance = d;
 	    result = *itNode;
@@ -85,7 +85,7 @@ namespace hpp {
 	return result;
       }
 
-      Nodes_t Basic::KnearestSearch (const ConfigurationPtr_t& configuration,
+      Nodes_t Basic::KnearestSearch (const Configuration_t& q,
           const ConnectedComponentPtr_t&
           connectedComponent,
           const std::size_t K,
@@ -94,7 +94,6 @@ namespace hpp {
         Queue_t ns;
         distance = std::numeric_limits <value_type>::infinity ();
         const Distance& dist = *distance_;
-        const Configuration_t& q = *configuration;
         for (NodeVector_t::const_iterator itNode =
             connectedComponent->nodes ().begin ();
             itNode != connectedComponent->nodes ().end (); ++itNode) {
@@ -142,14 +141,13 @@ namespace hpp {
         return nodes;
       }
 
-      Nodes_t Basic::KnearestSearch (const ConfigurationPtr_t& configuration,
+      Nodes_t Basic::KnearestSearch (const Configuration_t& q,
                                      const RoadmapPtr_t& roadmap,
                                      const std::size_t K, value_type& distance)
       {
         Queue_t ns;
         distance = std::numeric_limits <value_type>::infinity ();
         const Distance& dist = *distance_;
-        const Configuration_t& q = *configuration;
         for (Nodes_t::const_iterator itNode =
             roadmap->nodes ().begin ();
             itNode != roadmap->nodes ().end (); ++itNode) {

--- a/src/nearest-neighbor/basic.hh
+++ b/src/nearest-neighbor/basic.hh
@@ -51,12 +51,12 @@ namespace hpp {
         connectedComponent,
              value_type& distance);
 
-      virtual NodePtr_t search (const ConfigurationPtr_t& configuration,
+      virtual NodePtr_t search (const Configuration_t& configuration,
 			       const ConnectedComponentPtr_t&
 				connectedComponent,
              value_type& distance, bool reverse = false);
 
-      virtual Nodes_t KnearestSearch (const ConfigurationPtr_t& configuration,
+      virtual Nodes_t KnearestSearch (const Configuration_t& configuration,
                                       const ConnectedComponentPtr_t&
                                         connectedComponent,
                                       const std::size_t K,
@@ -74,7 +74,7 @@ namespace hpp {
       /// \param K the number of nearest neighbors to return
       /// \retval distance to the Kth closest neighbor
       /// \return the K nearest neighbors
-      virtual Nodes_t KnearestSearch (const ConfigurationPtr_t& configuration,
+      virtual Nodes_t KnearestSearch (const Configuration_t& configuration,
                                       const RoadmapPtr_t& roadmap,
                                       const std::size_t K,
 			              value_type& distance);

--- a/src/nearest-neighbor/k-d-tree.cc
+++ b/src/nearest-neighbor/k-d-tree.cc
@@ -219,34 +219,34 @@ namespace hpp {
     }
 
 
-    value_type KDTree::distanceToBox (const ConfigurationPtr_t& configuration) {
+    value_type KDTree::distanceToBox (const Configuration_t& configuration) {
       value_type minDistance;
       value_type DistanceToUpperBound;
       value_type DistanceToLowerBound;
       // Projection of the configuration on the box
-      Configuration_t confbox = *configuration;
+      Configuration_t confbox = configuration;
 
       DistanceToLowerBound = fabs (lowerBounds_[splitDim_] -
-				   (*configuration) [splitDim_])
+				   configuration [splitDim_])
 	* weights_ [splitDim_];
       DistanceToUpperBound = fabs (upperBounds_[splitDim_] -
-				   (*configuration)[splitDim_])
+				   configuration[splitDim_])
 	* weights_ [splitDim_];
       minDistance = std::min (DistanceToLowerBound, DistanceToUpperBound);
       return minDistance;
     }
 
-    NodePtr_t KDTree::search (const ConfigurationPtr_t& configuration,
+    NodePtr_t KDTree::search (const Configuration_t& configuration,
             const ConnectedComponentPtr_t& connectedComponent,
                               value_type& minDistance, bool) {
       // Test if the configuration is in the root box
       for ( std::size_t i=0 ; i<dim_ ; i++ ) {
-	if ( (*configuration)[i] < lowerBounds_[i] || (*configuration)[i]
+	if ( configuration[i] < lowerBounds_[i] || configuration[i]
 	     > upperBounds_[i] ) {
 	  std::ostringstream oss ("The Configuration isn't in the root box: \n"
 				  "  i = ");
 	  oss << i << ", lower = " << lowerBounds_[i] << ", config = "
-	      << (*configuration)[i] << ", upper = " << upperBounds_[i]
+	      << configuration[i] << ", upper = " << upperBounds_[i]
 	      << ".";
 	  throw std::runtime_error (oss.str ());
 	}
@@ -263,7 +263,7 @@ namespace hpp {
     NodePtr_t KDTree::search (const NodePtr_t& node,
             const ConnectedComponentPtr_t& connectedComponent,
                               value_type& minDistance) {
-      return search (node->configuration (), connectedComponent, minDistance);
+      return search (*node->configuration (), connectedComponent, minDistance);
     }
 
     Nodes_t KDTree::KnearestSearch (const NodePtr_t&,
@@ -273,14 +273,14 @@ namespace hpp {
       assert (false && "K-nearest neighbor in KD-tree: unimplemented features");
     }
 
-    Nodes_t KDTree::KnearestSearch (const ConfigurationPtr_t&,
+    Nodes_t KDTree::KnearestSearch (const Configuration_t&,
         const ConnectedComponentPtr_t&, const std::size_t,
         value_type&)
     {
       assert (false && "K-nearest neighbor in KD-tree: unimplemented features");
     }
 
-    Nodes_t KDTree::KnearestSearch (const ConfigurationPtr_t& configuration,
+    Nodes_t KDTree::KnearestSearch (const Configuration_t& configuration,
                                     const RoadmapPtr_t& roadmap,
                                     const std::size_t K, value_type& distance)
     {
@@ -288,7 +288,7 @@ namespace hpp {
     }
 
     void KDTree::search (value_type boxDistance, value_type& minDistance,
-			 const ConfigurationPtr_t& configuration,
+			 const Configuration_t& configuration,
 			 const ConnectedComponentPtr_t& connectedComponent,
        NodePtr_t& nearest,bool reverse) {
       if ( boxDistance < minDistance*minDistance
@@ -300,9 +300,9 @@ namespace hpp {
 		 nodesMap_[connectedComponent].begin ();
 	       itNode != nodesMap_[connectedComponent].end (); ++itNode) {
       if(reverse)
-        distance = (*distance_) (*configuration,*((*itNode)->configuration ()));
+        distance = (*distance_) (configuration,*((*itNode)->configuration ()));
       else
-        distance = (*distance_) (*((*itNode)->configuration ()),*configuration);
+        distance = (*distance_) (*((*itNode)->configuration ()),configuration);
 	    if (distance < minDistance) {
 	      minDistance = distance;
 	      nearest = (*itNode);
@@ -314,7 +314,7 @@ namespace hpp {
 	  value_type distanceToInfChild;
 	  value_type distanceToSupChild;
 	  if ( boxDistance == 0. ) {
-	    if ( (*configuration) [supChild_->splitDim_]
+	    if ( configuration [supChild_->splitDim_]
 		 > supChild_->lowerBounds_[supChild_->splitDim_])  {
 	      distanceToSupChild = 0.;
 	      distanceToInfChild = infChild_->distanceToBox(configuration);

--- a/src/nearest-neighbor/k-d-tree.hh
+++ b/src/nearest-neighbor/k-d-tree.hh
@@ -48,7 +48,7 @@ namespace hpp {
       virtual void clear();
 
       // search nearest node
-      virtual NodePtr_t search (const ConfigurationPtr_t& configuration,
+      virtual NodePtr_t search (const Configuration_t& configuration,
 			        const ConnectedComponentPtr_t&
 				connectedComponent,
         value_type& minDistance, bool reverse = false);
@@ -65,7 +65,7 @@ namespace hpp {
                                       const std::size_t K,
                                       value_type& distance);
 
-      virtual Nodes_t KnearestSearch (const ConfigurationPtr_t& configuration,
+      virtual Nodes_t KnearestSearch (const Configuration_t& configuration,
                                       const ConnectedComponentPtr_t&
                                         connectedComponent,
                                       const std::size_t K,
@@ -77,7 +77,7 @@ namespace hpp {
       /// \param K the number of nearest neighbors to return
       /// \retval distance to the Kth closest neighbor
       /// \return the K nearest neighbors
-      virtual Nodes_t KnearestSearch (const ConfigurationPtr_t& configuration,
+      virtual Nodes_t KnearestSearch (const Configuration_t& configuration,
                                       const RoadmapPtr_t& roadmap,
                                       const std::size_t K,
 			              value_type& distance);
@@ -127,11 +127,11 @@ namespace hpp {
       void findDeviceBounds();
 
       // distance to the nearest bound on the splited dimention
-      value_type distanceToBox(const ConfigurationPtr_t& configuration);
+      value_type distanceToBox(const Configuration_t& configuration);
 
       // search nearest node
       void search(value_type boxDistance, value_type& minDistance,
-      const ConfigurationPtr_t& configuration,
+      const Configuration_t& configuration,
       const ConnectedComponentPtr_t& connectedComponent,
       NodePtr_t& nearest, bool reverse = false);
 

--- a/src/path-planner.cc
+++ b/src/path-planner.cc
@@ -196,7 +196,7 @@ namespace hpp {
            itCC != roadmap ()->connectedComponents ().end (); ++itCC) {
         if (*itCC != initCC) {
           value_type d;
-          NodePtr_t near (nn->search (initNode->configuration (),
+          NodePtr_t near (nn->search (*initNode->configuration (),
                                       *itCC, d, true));
           assert (near);
           ConfigurationPtr_t q1 (initNode->configuration ());
@@ -226,7 +226,7 @@ namespace hpp {
              itCC != roadmap ()->connectedComponents ().end (); ++itCC) {
           if (*itCC != goalCC) {
             value_type d;
-            NodePtr_t near (nn->search ((*itn)->configuration (), *itCC, d,
+            NodePtr_t near (nn->search (*(*itn)->configuration (), *itCC, d,
                                         false));
             assert (near);
             ConfigurationPtr_t q1 (near->configuration ());

--- a/src/path-planner/k-prm-star.cc
+++ b/src/path-planner/k-prm-star.cc
@@ -94,7 +94,7 @@ namespace hpp {
       void kPrmStar::generateRandomConfig ()
       {
 	// shoot a valid random configuration
-	ConfigurationPtr_t qrand;
+	Configuration_t qrand;
 	// Report of configuration validation: unused here
 	ValidationReportPtr_t validationReport;
 	// Configuration validation methods associated to the problem
@@ -111,10 +111,10 @@ namespace hpp {
           bool valid (false);
           // After 10000 trials throw if no valid configuration has been found.
           do {
-            qrand = shooter->shoot ();
-            valid = (!constraints || constraints->apply (*qrand));
+            shooter->shoot (qrand);
+            valid = (!constraints || constraints->apply (qrand));
             if (valid)
-              valid = configValidations->validate (*qrand, validationReport);
+              valid = configValidations->validate (qrand, validationReport);
 	    nbTry++;
           } while (!valid && nbTry < 10000);
           if (!valid) {
@@ -126,7 +126,7 @@ namespace hpp {
           state_ = LINK_NODES;
           linkingNodeIt_ = r->nodes ().begin ();
           neighbors_ =roadmap ()->nearestNodes
-            ((*linkingNodeIt_)->configuration (), numberNeighbors_);
+            (*(*linkingNodeIt_)->configuration (), numberNeighbors_);
           itNeighbor_ = neighbors_.begin ();
         }
       }

--- a/src/problem-target/goal-configurations.cc
+++ b/src/problem-target/goal-configurations.cc
@@ -45,6 +45,7 @@ namespace hpp {
 
       bool GoalConfigurations::reached (const RoadmapPtr_t& roadmap) const
       {
+        if (!roadmap->initNode ()) return false;
         const ConnectedComponentPtr_t ccInit = roadmap->initNode ()->connectedComponent ();
         const NodeVector_t& goals = roadmap->goalNodes();
         for (NodeVector_t::const_iterator _goal = goals.begin (); _goal != goals.end (); ++_goal) {

--- a/src/roadmap.cc
+++ b/src/roadmap.cc
@@ -180,7 +180,7 @@ namespace hpp {
     }
 
     NodePtr_t
-    Roadmap::nearestNode (const ConfigurationPtr_t& configuration,
+    Roadmap::nearestNode (const Configuration_t& configuration,
         value_type& minDistance, bool reverse)
     {
       NodePtr_t closest = 0x0;
@@ -200,7 +200,7 @@ namespace hpp {
     }
 
     NodePtr_t
-    Roadmap::nearestNode (const ConfigurationPtr_t& configuration,
+    Roadmap::nearestNode (const Configuration_t& configuration,
         const ConnectedComponentPtr_t& connectedComponent,
         value_type& minDistance, bool reverse)
     {
@@ -211,7 +211,7 @@ namespace hpp {
       return closest;
     }
 
-    Nodes_t Roadmap::nearestNodes (const ConfigurationPtr_t& configuration,
+    Nodes_t Roadmap::nearestNodes (const Configuration_t& configuration,
                                    size_type k)
     {
       value_type d;
@@ -219,7 +219,7 @@ namespace hpp {
                                                d);
     }
 
-    Nodes_t Roadmap::nearestNodes (const ConfigurationPtr_t& configuration,
+    Nodes_t Roadmap::nearestNodes (const Configuration_t& configuration,
                                    const ConnectedComponentPtr_t&
                                    connectedComponent,
                                    size_type k)

--- a/tests/configuration-shooters.cc
+++ b/tests/configuration-shooters.cc
@@ -33,13 +33,12 @@ namespace pin_test = hpp::pinocchio::unittest;
 template <typename CS_t>
 void basic_test (CS_t cs, DevicePtr_t robot)
 {
+  hpp::core::Configuration_t q;
   for (int i = 0; i < 10; ++i)
   {
-    hpp::core::ConfigurationPtr_t cptr = cs->shoot();
-    BOOST_REQUIRE (cptr);
-    hpp::core::Configuration_t c = *cptr;
+    cs->shoot(q);
     hpp::pinocchio::ArrayXb unused(robot->numberDof());
-    BOOST_CHECK(!hpp::pinocchio::saturate(robot, c, unused));
+    BOOST_CHECK(!hpp::pinocchio::saturate(robot, q, unused));
   }
 }
 
@@ -61,5 +60,7 @@ BOOST_AUTO_TEST_CASE (gaussian)
 
   cs->sigma (0);
 
-  BOOST_CHECK(cs->shoot()->isApprox(cs->center()));
+  hpp::core::Configuration_t q;
+  cs->shoot(q);
+  BOOST_CHECK(q.isApprox(cs->center()));
 }

--- a/tests/explicit-relative-transformation.cc
+++ b/tests/explicit-relative-transformation.cc
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE (two_freeflyers)
 {
   DevicePtr_t robot = createRobot();
   BOOST_REQUIRE (robot);
-  configurationShooter::UniformPtr_t cs = configurationShooter::Uniform::create(robot);
+  ConfigurationShooterPtr_t cs = configurationShooter::Uniform::create(robot);
 
   JointPtr_t object2 = robot->getJointByName("obj2/root_joint");
   JointPtr_t object1  = robot->getJointByName("obj1/root_joint");
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE (two_frames_on_freeflyer)
 {
   DevicePtr_t robot = createRobot();
   BOOST_REQUIRE (robot);
-  configurationShooter::UniformPtr_t cs = configurationShooter::Uniform::create(robot);
+  ConfigurationShooterPtr_t cs = configurationShooter::Uniform::create(robot);
 
   JointPtr_t object2 = robot->getJointByName("obj2/root_joint");
   JointPtr_t object1  = robot->getJointByName("obj1/root_joint");
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE (compare_to_relative_transform)
 {
   DevicePtr_t robot = createRobot();
   BOOST_REQUIRE (robot);
-  configurationShooter::UniformPtr_t cs = configurationShooter::Uniform::create(robot);
+  ConfigurationShooterPtr_t cs = configurationShooter::Uniform::create(robot);
 
   JointPtr_t object2 = robot->getJointByName("obj2/root_joint");
   JointPtr_t object1  = robot->getJointByName("obj1/root_joint");

--- a/tests/roadmap-1.cc
+++ b/tests/roadmap-1.cc
@@ -369,7 +369,7 @@ BOOST_AUTO_TEST_CASE (nearestNeighbor) {
   hpp::pinocchio::value_type dist;
   using hpp::core::Nodes_t;
   Nodes_t knearest = r->nearestNeighbor()->KnearestSearch
-    (nodes[0]->configuration(), nodes[0]->connectedComponent (), 3, dist);
+    (*nodes[0]->configuration(), nodes[0]->connectedComponent (), 3, dist);
   for (Nodes_t::const_iterator it = knearest.begin (); it != knearest.end(); ++it) {
     BOOST_TEST_MESSAGE ("q = [" << (*it)->configuration()->transpose() << "] - dist : " << (*distance) (*nodes[0]->configuration(), *(*it)->configuration()));
   }

--- a/tests/test-kinodynamic.cc
+++ b/tests/test-kinodynamic.cc
@@ -410,7 +410,7 @@ BOOST_AUTO_TEST_CASE (kinodynamic) {
 
   // random tests with non null initial and final acceleration
 
-  configurationShooter::UniformPtr_t shooter = configurationShooter::Uniform::create(robot);
+  ConfigurationShooterPtr_t shooter = configurationShooter::Uniform::create(robot);
   ConfigurationPtr_t qr1,qr0;
   value_type t1,t2;
   for(size_t i = 0 ; i < 1000 ; i++){
@@ -607,7 +607,7 @@ BOOST_AUTO_TEST_CASE (kinodynamicOriented) {
   PathValidationReportPtr_t validationReport;
   PathPtr_t validPath;
 
-  configurationShooter::UniformPtr_t shooter = configurationShooter::Uniform::create(robot);
+  ConfigurationShooterPtr_t shooter = configurationShooter::Uniform::create(robot);
   ConfigurationPtr_t qr1,qr0;
   value_type t1,t2;
   for(size_t i = 0 ; i < 1000 ; i++){


### PR DESCRIPTION
This PR partially addresses #167   

The change is *almost* backward compatible. The only place where it is not are illustrated by 
22ee362 

This won't work because shoot is re-implemented in child classes.
```c++
  configurationShooter::UniformPtr_t cs = configurationShooter::Uniform::create(robot);
  ConfigurationPtr_t q = cs->shoot();
```
It should be replaced by
```c++
  ConfigurationShooterPtr_t cs = configurationShooter::Uniform::create(robot);
  ConfigurationPtr_t q = cs->shoot();
```
or even better
```c++
  ConfigurationShooterPtr_t cs = configurationShooter::Uniform::create(robot);
  Configuration_t q;
  cs->shoot(q); // q is resized if necessary, avoiding the need for 2 dynamic allocations at each call.
```