### PR TITLE
fix build with gcc 9 / -std=c++11

### DIFF
--- a/include/hpp/core/interpolated-path.hh
+++ b/include/hpp/core/interpolated-path.hh
@@ -41,7 +41,7 @@ namespace hpp {
     class HPP_CORE_DLLAPI InterpolatedPath : public Path
     {
     public:
-      typedef std::pair <value_type, Configuration_t> InterpolationPoint_t;
+      typedef std::pair <const value_type, Configuration_t> InterpolationPoint_t;
       typedef std::map <value_type, Configuration_t, std::less <value_type>,
         Eigen::aligned_allocator <InterpolationPoint_t> > InterpolationPoints_t;
       typedef Path parent_t;


### PR DESCRIPTION
Hi,

I got this error:

```
/usr/include/c++/9.2.0/bits/stl_map.h:122:71: erreur: l'assertion statique a échoué:
std::map must have the same value_type as its allocator
```

And the [template for `std::map`](https://fr.cppreference.com/w/cpp/container/map) is 

```cpp
template<
    class Key,
    class T,
    class Compare = std::less<Key>,
    class Allocator = std::allocator<std::pair<const Key, T> >
> class map;
```

So I guess we were missing the `const` in `std::pair<const Key, T>`.