### PR TITLE
Fix problemTarget::GoalConfigurations::computePath

### DIFF
--- a/include/hpp/core/steering-method.hh
+++ b/include/hpp/core/steering-method.hh
@@ -41,15 +41,19 @@ namespace hpp {
       /// create a path between two configurations
       /// \return a Path from q1 to q2 if found. An empty
       /// Path if Path could not be built.
+      /// \note if q1 == q2, the steering method should not return an empty
+      ///       shared pointer.
       PathPtr_t operator() (ConfigurationIn_t q1,
 			    ConfigurationIn_t q2) const
       {
+        PathPtr_t path;
         try {
-          return impl_compute (q1, q2);
+          path = impl_compute (q1, q2);
         } catch (const projection_error& e) {
           hppDout (info, "Could not build path: " << e.what());
         }
-	return PathPtr_t ();
+        assert (q1 != q2 || path);
+	return path;
       }
 
       /// \copydoc SteeringMethod::operator()(ConfigurationIn_t,ConfigurationIn_t)


### PR DESCRIPTION
This PR adds a constructor in class PathVector that takes as input a device and a configuration.
This constructor stores in the PathVector instance a straight path of length 0 starting and ending at the input configuration.
This straight path is remove as soon as another path is appended to the PathVector instance.

This solves https://github.com/humanoid-path-planner/hpp-core/issues/193.