### PR TITLE
[ContinuousValidation] Fix delegate insertion.

### DIFF
--- a/include/hpp/core/continuous-validation.hh
+++ b/include/hpp/core/continuous-validation.hh
@@ -77,6 +77,7 @@ namespace hpp {
         Initialize(ContinuousValidation& owner);
         /// Initialize ContinuousValidation class
         virtual void doExecute() const;
+        virtual ~Initialize () {}
       protected:
         ContinuousValidation& owner_;
       }; // class Initialize
@@ -92,6 +93,7 @@ namespace hpp {
         /// Add the object to each collision pair a body of which is the
         /// environment.
         virtual void doExecute(const CollisionObjectConstPtr_t &object) const;
+        virtual ~AddObstacle () {}
       protected:
         ContinuousValidation& owner_;
         DeviceWkPtr_t robot_;
@@ -278,6 +280,20 @@ namespace hpp {
       std::vector<AddObstacle> addObstacle_;
     }; // class ContinuousValidation
     /// \}
+    template <>
+    void ContinuousValidation::add<ContinuousValidation::AddObstacle>
+    (const ContinuousValidation::AddObstacle& delegate);
+
+    template <>
+    void ContinuousValidation::reset<ContinuousValidation::AddObstacle>();
+
+    template <>
+    void ContinuousValidation::add<ContinuousValidation::Initialize>
+    (const ContinuousValidation::Initialize& delegate);
+
+    template <>
+    void ContinuousValidation::reset<ContinuousValidation::Initialize>();
+
     template <class Delegate> void ContinuousValidation::add
     (const Delegate& delegate)
     {

--- a/src/continuous-validation.cc
+++ b/src/continuous-validation.cc
@@ -392,8 +392,8 @@ namespace hpp {
       if (tolerance < 0) {
         throw std::runtime_error ("tolerance should be non-negative.");
       }
-      add(Initialize(*this));
-      add(AddObstacle(*this));
+      add<Initialize>(Initialize(*this));
+      add<AddObstacle>(AddObstacle(*this));
     }
   } // namespace core
 } // namespace hpp


### PR DESCRIPTION
Declaration of template specialization were in file `src/continuous-validation.cc`, while definition of default template implementations were in `include/hpp/core/continuous-validation.hh` and therefore the former were not taken into account in projects depending on hpp-core.
What I do not understand is that the bug did not seem to appear in hpp-core tests.