### PR TITLE
Improve Vmax computation for solid-solid collision

### DIFF
--- a/include/hpp/core/continuous-validation/solid-solid-collision.hh
+++ b/include/hpp/core/continuous-validation/solid-solid-collision.hh
@@ -149,7 +149,8 @@ namespace hpp {
           CoefficientVelocities_t coefficients;
           CoefficientVelocities_t coefficients_reverse;
           JointIndices_t computeSequenceOfJoints () const;
-          void computeCoefficients (const JointIndices_t& joints);
+          CoefficientVelocities_t computeCoefficients (const JointIndices_t& joints) const;
+          void setCoefficients (const JointIndices_t& joints);
         };
         shared_ptr<Model> m_;
         SolidSolidCollisionWkPtr_t weak_;

--- a/include/hpp/core/continuous-validation/solid-solid-collision.hh
+++ b/include/hpp/core/continuous-validation/solid-solid-collision.hh
@@ -147,6 +147,7 @@ namespace hpp {
           JointPtr_t joint_a;
           JointPtr_t joint_b;
           CoefficientVelocities_t coefficients;
+          CoefficientVelocities_t coefficients_reverse;
           JointIndices_t computeSequenceOfJoints () const;
           void computeCoefficients (const JointIndices_t& joints);
         };

--- a/src/continuous-validation/solid-solid-collision.cc
+++ b/src/continuous-validation/solid-solid-collision.cc
@@ -285,7 +285,7 @@ namespace hpp {
         }
         // Find sequence of joints
         JointIndices_t joints (m_->computeSequenceOfJoints ());
-        m_->computeCoefficients (joints);
+        m_->setCoefficients (joints);
       }
 
       void SolidSolidCollision::init(const SolidSolidCollisionWkPtr_t& weak)


### PR DESCRIPTION
When considering a solid-solid collision pair, the computation of Vmax is not symmetric and the value changes when considering the sequence of joints from body A to body B or from body B to body A. With this change, we compute the two values for Vmax and choose the best (smallest) one.