### PR TITLE
[SimpleTimeParameterization] Fix method optimize.

### DIFF
--- a/src/path-optimization/simple-time-parameterization.cc
+++ b/src/path-optimization/simple-time-parameterization.cc
@@ -215,10 +215,10 @@ namespace hpp {
           p->timeParameterization (TimeParameterizationPtr_t(), paramRange);
 
           PathPtr_t pp = p->copy();
-          if (p->length() > 0) {
-            output->appendPath (pp);
-            continue;
-          }
+          // if (p->length() > 0) {
+          //   output->appendPath (pp);
+          //   continue;
+          // }
           // Compute B
           p->velocityBound (v, paramRange.first, paramRange.second);
           v_inv = (v.array() == 0).select(infinity, v.cwiseInverse());


### PR DESCRIPTION
  Comment lines that make method optimize leave the input path unchanged.
  This lines have been introduced in commit 01876e31b0eef8.