### PR TITLE
Handle null length paths in TOPPRA

### DIFF
--- a/plugins/toppra.cc
+++ b/plugins/toppra.cc
@@ -148,6 +148,12 @@ PathVectorPtr_t TOPPRA::optimize(const PathVectorPtr_t &path)
   PathVectorPtr_t flatten_path = PathVector::create(path->outputSize(), path->outputDerivativeSize());
   path->flatten(flatten_path);
 
+  const value_type min_path_length = 1e-6;
+  if (path->length() < min_path_length)
+  {
+    return flatten_path;
+  }
+
   size_type N = problem()->getParameter(PARAM_HEAD "N").intValue();
 
   // 1. Compute TOPPRA grid points (in the parameter space).


### PR DESCRIPTION
TOPPRA solver returns an error (code 2) for null length paths, but others HPP path optimizers handle this case (looks like to be done by skipping path optimization). 
I'm currently using this fix to homogenize the null length path case with TOPPRA and it works fine. But I'm not sure about the general way to handle null length path cases in HPP. It seems that in HPP null length paths exists (such as when a path between start and goal nodes having similar configurations) and can be returned by the solver, which would mean that handling theses cases is done by HPP and not by the user (which in my opinion is preferable), but I might have misunderstood HPP behavior here.

Any suggestions about this ?