### PR TITLE
Add condition for reaching goal node for task target

### DIFF
--- a/src/problem-target/task-target.cc
+++ b/src/problem-target/task-target.cc
@@ -59,10 +59,19 @@ namespace hpp {
         }
       }
 
-      bool TaskTarget::reached (const RoadmapPtr_t& /*roadmap*/) const
+      bool TaskTarget::reached (const RoadmapPtr_t& roadmap) const
       {
-        // TODO
-        return false;
+        assert(roadmap->goalNodes().empty());
+        if (!roadmap->initNode ()) return false;
+        const ConnectedComponentPtr_t ccInit = roadmap->initNode ()->connectedComponent ();  // TODO
+        bool res(false);
+        for (auto node : ccInit->nodes()){
+          if ((*constraints_).isSatisfied(*(node->configuration()))){
+            roadmap->addGoalNode(node->configuration()); // temporarily add goal node to compute path
+            res = true;
+          }
+        }
+        return res;
       }
 
       NumericalConstraints_t TaskTarget::constraints() const
@@ -88,6 +97,7 @@ namespace hpp {
               (*problem->steeringMethod()) (*q, *q)
               );
         }
+        roadmap->resetGoalNodes(); // remove the temporary goal node
         return sol;
       }
     } // namespace problemTarget


### PR DESCRIPTION
When the goal is defined as a set of constraints instead of a specific configuration, there is no specified "goal node". To check that the goal has been reached, we can check the nodes in the connected components of the initial node if there exists a node satisfying all the goal constraints. If yes, we can temporarily regard this node as goal node to compute path, and remove it once a path has been completed.