### PR TITLE
Add operator< between connected components

### DIFF
--- a/include/hpp/core/connected-component.hh
+++ b/include/hpp/core/connected-component.hh
@@ -89,9 +89,13 @@ class HPP_CORE_DLLAPI ConnectedComponent {
 
   ConnectedComponentPtr_t self() { return weak_.lock(); }
 
+  bool operator <(const ConnectedComponent& rhs) const {
+     return this->current_id < rhs.current_id;
+  }
+
  protected:
   /// Constructor
-  ConnectedComponent() : nodes_(), explored_(false), weak_() {
+  ConnectedComponent() : nodes_(), explored_(false), weak_(), current_id(static_id++) {
     nodes_.reserve(1000);
   }
   void init(const ConnectedComponentPtr_t& shPtr) { weak_ = shPtr; }
@@ -108,6 +112,9 @@ class HPP_CORE_DLLAPI ConnectedComponent {
   mutable bool explored_;
   ConnectedComponentWkPtr_t weak_;
   friend class Roadmap;
+
+   static int static_id;
+   const int current_id;
 
   HPP_SERIALIZABLE();
 };  // class ConnectedComponent

--- a/include/hpp/core/fwd.hh
+++ b/include/hpp/core/fwd.hh
@@ -114,7 +114,15 @@ typedef shared_ptr<ConfigProjector> ConfigProjectorPtr_t;
 typedef shared_ptr<ConfigValidation> ConfigValidationPtr_t;
 typedef shared_ptr<ConfigValidations> ConfigValidationsPtr_t;
 typedef shared_ptr<ConnectedComponent> ConnectedComponentPtr_t;
-typedef std::set<ConnectedComponentPtr_t> ConnectedComponents_t;
+
+struct SharedComparator {
+    template <typename T>
+    bool operator()(const std::shared_ptr<T>& lhs, const std::shared_ptr<T>& rhs) const {
+        return (*lhs) < (*rhs);
+    }
+};
+typedef std::set<ConnectedComponentPtr_t, SharedComparator> ConnectedComponents_t;
+
 typedef shared_ptr<Constraint> ConstraintPtr_t;
 typedef shared_ptr<ConstraintSet> ConstraintSetPtr_t;
 typedef shared_ptr<const ConstraintSet> ConstraintSetConstPtr_t;

--- a/src/connected-component.cc
+++ b/src/connected-component.cc
@@ -172,5 +172,8 @@ bool ConnectedComponent::canReach(const ConnectedComponentPtr_t& cc,
   return true;
 }
 
+int ConnectedComponent::static_id = 0;
+
+
 }  //   namespace core
 }  // namespace hpp


### PR DESCRIPTION
This modification makes random sampling replicable by setting a seed.
This solves https://github.com/humanoid-path-planner/hpp-core/issues/274.