### PR TITLE
[WIP] Use only noexcept for C++>=11

### DIFF
--- a/include/hpp/core/path-planning-failed.hh
+++ b/include/hpp/core/path-planning-failed.hh
@@ -41,13 +41,8 @@ struct HPP_CORE_DLLAPI path_planning_failed : public std::exception {
   path_planning_failed(const path_planning_failed& other)
       : std::exception(other), msg_(other.msg_) {}
 
-#if __cplusplus >= 201103L
   virtual ~path_planning_failed() noexcept {};
   virtual const char* what() const noexcept { return msg_.c_str(); };
-#else
-  virtual ~path_planning_failed() _GLIBCXX_USE_NOEXCEPT{};
-  virtual const char* what() const throw() { return msg_.c_str(); };
-#endif
 
   std::string msg_;
 };

--- a/include/hpp/core/path-planning-failed.hh
+++ b/include/hpp/core/path-planning-failed.hh
@@ -41,9 +41,13 @@ struct HPP_CORE_DLLAPI path_planning_failed : public std::exception {
   path_planning_failed(const path_planning_failed& other)
       : std::exception(other), msg_(other.msg_) {}
 
-  virtual ~path_planning_failed() _GLIBCXX_USE_NOEXCEPT{};
-
+#if __cplusplus >= 201103L
+  virtual ~path_planning_failed() noexcept {};
   virtual const char* what() const noexcept { return msg_.c_str(); };
+#else
+  virtual ~path_planning_failed() _GLIBCXX_USE_NOEXCEPT{};
+  virtual const char* what() const throw() { return msg_.c_str(); };
+#endif
 
   std::string msg_;
 };

--- a/include/hpp/core/projection-error.hh
+++ b/include/hpp/core/projection-error.hh
@@ -42,11 +42,11 @@ struct HPP_CORE_DLLAPI projection_error : public std::exception {
   projection_error(const projection_error& other)
       : std::exception(other), msg_(other.msg_) {}
 
-  virtual ~projection_error() _GLIBCXX_USE_NOEXCEPT{};
-
 #if __cplusplus >= 201103L
+  virtual ~projection_error() noexcept {};
   virtual const char* what() const noexcept { return msg_.c_str(); };
 #else
+  virtual ~projection_error() _GLIBCXX_USE_NOEXCEPT{};
   virtual const char* what() const throw() { return msg_.c_str(); };
 #endif
 

--- a/include/hpp/core/projection-error.hh
+++ b/include/hpp/core/projection-error.hh
@@ -42,13 +42,8 @@ struct HPP_CORE_DLLAPI projection_error : public std::exception {
   projection_error(const projection_error& other)
       : std::exception(other), msg_(other.msg_) {}
 
-#if __cplusplus >= 201103L
   virtual ~projection_error() noexcept {};
   virtual const char* what() const noexcept { return msg_.c_str(); };
-#else
-  virtual ~projection_error() _GLIBCXX_USE_NOEXCEPT{};
-  virtual const char* what() const throw() { return msg_.c_str(); };
-#endif
 
   std::string msg_;
 };


### PR DESCRIPTION
With some modern compiler with light install, `_GLIBCXX_USE_NOEXCEPT` is deprecated and only `noexcept` should be use. This PR make it more consistence and is still compatible with c++ < 11