### PR TITLE
Update to match new logic of cmake JRL submodule of deprecated with typedef

### DIFF
--- a/include/hpp/core/path-vector.hh
+++ b/include/hpp/core/path-vector.hh
@@ -122,7 +122,7 @@ class HPP_CORE_DLLAPI PathVector : public Path {
   /// Concatenate two vectors of path
   /// \deprecated use void method concatenate (const PathVectorPtr_t& path)
   ///             instead.
-  void concatenate(const PathVector& path) HPP_CORE_DEPRECATED;
+  HPP_CORE_DEPRECATED void concatenate(const PathVector& path);
 
   /// Concatenate two vectors of path
   /// \param path path to append at the end of this one

--- a/include/hpp/core/path.hh
+++ b/include/hpp/core/path.hh
@@ -129,7 +129,7 @@ class HPP_CORE_DLLAPI Path {
   /// Configuration at time
   /// \deprecated use eval instead
   HPP_CORE_DEPRECATED Configuration_t operator()(const value_type& time,
-                             bool& success) const {
+                                                 bool& success) const {
     return eval(time, success);
   }
 

--- a/include/hpp/core/path.hh
+++ b/include/hpp/core/path.hh
@@ -128,8 +128,8 @@ class HPP_CORE_DLLAPI Path {
 
   /// Configuration at time
   /// \deprecated use eval instead
-  Configuration_t operator()(const value_type& time,
-                             bool& success) const HPP_CORE_DEPRECATED {
+  HPP_CORE_DEPRECATED Configuration_t operator()(const value_type& time,
+                             bool& success) const {
     return eval(time, success);
   }
 

--- a/include/hpp/core/problem.hh
+++ b/include/hpp/core/problem.hh
@@ -141,7 +141,7 @@ class HPP_CORE_DLLAPI Problem {
   /// Reset the ConfigValidations
   /// by creating a new ConfigValidations using ConfigValidations::create
   /// \deprecated Use clear instead.
-  void resetConfigValidations() HPP_CORE_DEPRECATED;
+  HPP_CORE_DEPRECATED void resetConfigValidations();
 
   /// Clear the ConfigValidations
   /// by calling ConfigValidations::clear


### PR DESCRIPTION
It follows the issue raised in JRL cmake submodules : https://github.com/jrl-umi3218/jrl-cmakemodules/issues/563#issuecomment-1308090359
