### PR TITLE
make code robust to boost/std shared_ptr for fcl object

### DIFF
--- a/include/hpp/core/fwd.hh
+++ b/include/hpp/core/fwd.hh
@@ -97,10 +97,7 @@ typedef shared_ptr<AllCollisionsValidationReport>
     AllCollisionsValidationReportPtr_t;
 typedef pinocchio::CollisionObjectPtr_t CollisionObjectPtr_t;
 typedef pinocchio::CollisionObjectConstPtr_t CollisionObjectConstPtr_t;
-typedef pinocchio::FclCollisionObject FclCollisionObject;
-typedef FclCollisionObject* FclCollisionObjectPtr_t;
-typedef const FclCollisionObject* FclConstCollisionObjectPtr_t;
-typedef shared_ptr<FclCollisionObject> FclCollisionObjectSharePtr_t;
+typedef pinocchio::CollisionGeometryPtr_t CollisionGeometryPtr_t;
 
 typedef pinocchio::Configuration_t Configuration_t;
 typedef pinocchio::ConfigurationIn_t ConfigurationIn_t;

--- a/include/hpp/core/problem-solver.hh
+++ b/include/hpp/core/problem-solver.hh
@@ -409,12 +409,14 @@ class HPP_CORE_DLLAPI ProblemSolver {
 
   /// Add obstacle to the list.
   /// \param inObject a new object.
+  /// \param pose the object pose.
   /// \param collision whether collision checking should be performed
   ///        for this object.
   /// \param distance whether distance computation should be performed
   ///        for this object.
   virtual void addObstacle(const std::string& name,
-                           /*const*/ FclCollisionObject& inObject,
+                           const CollisionGeometryPtr_t& inObject,
+                           const Transform3f& pose,
                            bool collision, bool distance);
 
   /// Remove collision pair between a joint and an obstacle

--- a/include/hpp/core/problem-solver.hh
+++ b/include/hpp/core/problem-solver.hh
@@ -416,8 +416,8 @@ class HPP_CORE_DLLAPI ProblemSolver {
   ///        for this object.
   virtual void addObstacle(const std::string& name,
                            const CollisionGeometryPtr_t& inObject,
-                           const Transform3f& pose,
-                           bool collision, bool distance);
+                           const Transform3f& pose, bool collision,
+                           bool distance);
 
   /// Remove collision pair between a joint and an obstacle
   /// \param jointName name of the joint,

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -829,20 +829,21 @@ void ProblemSolver::addObstacle(const DevicePtr_t& device, bool collision,
   for (size_type i = 0; i < device->nbObjects(); ++i) {
     CollisionObjectPtr_t obj = device->objectAt(i);
     addObstacle(prefix + obj->name(), obj->geometry(), obj->getTransform(),
-        collision, distance);
+                collision, distance);
   }
 }
 
 void ProblemSolver::addObstacle(const CollisionObjectPtr_t& object,
                                 bool collision, bool distance) {
   // FIXME propagate object->mesh_path ?
-  addObstacle(object->name(), object->geometry(), object->getTransform(), collision, distance);
+  addObstacle(object->name(), object->geometry(), object->getTransform(),
+              collision, distance);
 }
 
 void ProblemSolver::addObstacle(const std::string& name,
                                 const CollisionGeometryPtr_t& inObject,
-                                const Transform3f& pose,
-                                bool collision, bool distance) {
+                                const Transform3f& pose, bool collision,
+                                bool distance) {
   if (obstacleModel_->existGeometryName(name)) {
     HPP_THROW(std::runtime_error,
               "object with name "
@@ -851,7 +852,7 @@ void ProblemSolver::addObstacle(const std::string& name,
 
   ::pinocchio::GeomIndex id = obstacleModel_->addGeometryObject(
       ::pinocchio::GeometryObject(name, 1, 0, inObject, pose, "",
-          vector3_t::Ones()),
+                                  vector3_t::Ones()),
       *obstacleRModel_);
   // Update obstacleData_
   // FIXME This should be done in Pinocchio

--- a/tests/problem.cc
+++ b/tests/problem.cc
@@ -86,10 +86,9 @@ void pointMassProblem(const char* steeringMethod, const char* distance,
   ps->steeringMethodType(steeringMethod);
   ps->distanceType(distance);
 
-  FclCollisionObject box(
-      hpp::fcl::CollisionGeometryPtr_t(new hpp::fcl::Box(0.3, 0.3, 0.3)),
-      matrix3_t::Identity(), vector3_t(-2, 0, 0));
-  ps->addObstacle("box", box, true, true);
+  CollisionGeometryPtr_t boxGeom(new hpp::fcl::Box(0.3, 0.3, 0.3));
+  SE3 boxTf(matrix3_t::Identity(), vector3_t(-2, 0, 0));
+  ps->addObstacle("box", boxGeom, boxTf, true, true);
 
   ConfigurationPtr_t qinit(new Configuration_t(robot->neutralConfiguration()));
   ConfigurationPtr_t qgoal(new Configuration_t(robot->neutralConfiguration()));
@@ -122,10 +121,9 @@ void carLikeProblem(const char* steeringMethod, const char* distance,
   ps->steeringMethodType(steeringMethod);
   ps->distanceType(distance);
 
-  FclCollisionObject box(
-      hpp::fcl::CollisionGeometryPtr_t(new hpp::fcl::Box(0.3, 0.3, 0.3)),
-      matrix3_t::Identity(), vector3_t(-2, 0, 0));
-  ps->addObstacle("box", box, true, true);
+  CollisionGeometryPtr_t boxGeom(new hpp::fcl::Box(0.3, 0.3, 0.3));
+  SE3 boxTf(matrix3_t::Identity(), vector3_t(-2, 0, 0));
+  ps->addObstacle("box", boxGeom, boxTf, true, true);
 
   ConfigurationPtr_t qinit(new Configuration_t(robot->neutralConfiguration()));
   ConfigurationPtr_t qgoal(new Configuration_t(robot->neutralConfiguration()));


### PR DESCRIPTION
Functionally, for an exactly identical behavior, this requires https://github.com/humanoid-path-planner/hpp-fcl/pull/360 but I guess function `cutObstacle` has never been used except by me :smile:
Nevertheless, I think even without it, it is just slower but works correctly.