### PR TITLE
Partially Revert "make code robust to boost/std shared_ptr for fcl object"

### DIFF
--- a/include/hpp/core/fwd.hh
+++ b/include/hpp/core/fwd.hh
@@ -98,6 +98,10 @@ typedef shared_ptr<AllCollisionsValidationReport>
 typedef pinocchio::CollisionObjectPtr_t CollisionObjectPtr_t;
 typedef pinocchio::CollisionObjectConstPtr_t CollisionObjectConstPtr_t;
 typedef pinocchio::CollisionGeometryPtr_t CollisionGeometryPtr_t;
+typedef pinocchio::FclCollisionObject FclCollisionObject;
+typedef FclCollisionObject* FclCollisionObjectPtr_t;
+typedef const FclCollisionObject* FclConstCollisionObjectPtr_t;
+typedef shared_ptr<FclCollisionObject> FclCollisionObjectSharePtr_t;
 
 typedef pinocchio::Configuration_t Configuration_t;
 typedef pinocchio::ConfigurationIn_t ConfigurationIn_t;

--- a/include/hpp/core/problem-solver.hh
+++ b/include/hpp/core/problem-solver.hh
@@ -419,6 +419,16 @@ class HPP_CORE_DLLAPI ProblemSolver {
                            const Transform3f& pose, bool collision,
                            bool distance);
 
+  /// Add obstacle to the list.
+  /// \param inObject a new object.
+  /// \param collision whether collision checking should be performed
+  ///        for this object.
+  /// \param distance whether distance computation should be performed
+  ///        for this object.
+  virtual void addObstacle(const std::string& name,
+                           /*const*/ FclCollisionObject& inObject,
+                           bool collision, bool distance);
+
   /// Remove collision pair between a joint and an obstacle
   /// \param jointName name of the joint,
   /// \param obstacleName name of the obstacle

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -926,7 +926,6 @@ void ProblemSolver::addObstacle(const std::string& name,
   }
 }
 
-
 void ProblemSolver::removeObstacle(const std::string& name) {
   if (!obstacleModel_->existGeometryName(name)) {
     HPP_THROW(std::invalid_argument, "No obstacle with name " << name);

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -885,6 +885,48 @@ void ProblemSolver::addObstacle(const std::string& name,
   }
 }
 
+void ProblemSolver::addObstacle(const std::string& name,
+                                /*const*/ FclCollisionObject& inObject,
+                                bool collision, bool distance) {
+  if (obstacleModel_->existGeometryName(name)) {
+    HPP_THROW(std::runtime_error,
+              "object with name "
+                  << name << " already added! Choose another name (prefix).");
+  }
+
+  ::pinocchio::GeomIndex id = obstacleModel_->addGeometryObject(
+      ::pinocchio::GeometryObject(
+          name, 1, 0, inObject.collisionGeometry(),
+          ::pinocchio::toPinocchioSE3(inObject.getTransform()), "",
+          vector3_t::Ones()),
+      *obstacleRModel_);
+  // Update obstacleData_
+  // FIXME This should be done in Pinocchio
+  {
+    ::pinocchio::GeometryModel& model = *obstacleModel_;
+    ::pinocchio::GeometryData& data = *obstacleData_;
+    data.oMg.resize(model.ngeoms);
+    // data.activeCollisionPairs.resize(model.collisionPairs.size(), true)
+    // data.distance_results(model.collisionPairs.size())
+    // data.collision_results(model.collisionPairs.size())
+    // data.radius()
+    data.oMg[id] = model.geometryObjects[id].placement;
+  }
+  CollisionObjectPtr_t object(
+      new CollisionObject(obstacleModel_, obstacleData_, id));
+
+  if (collision) {
+    collisionObstacles_.push_back(object);
+    resetRoadmap();
+  }
+  if (distance) distanceObstacles_.push_back(object);
+  if (problem()) problem()->addObstacle(object);
+  if (distanceBetweenObjects_) {
+    distanceBetweenObjects_->addObstacle(object);
+  }
+}
+
+
 void ProblemSolver::removeObstacle(const std::string& name) {
   if (!obstacleModel_->existGeometryName(name)) {
     HPP_THROW(std::invalid_argument, "No obstacle with name " << name);


### PR DESCRIPTION


This partially reverts commit e9bd254f4d5152b3d9a06fdac99bf7f3eda5d52e, since we can now have std shared_ptr everywhere, there is no need to break the API