### PR TITLE
Fix spline steering method when path length != 1

### DIFF
--- a/include/hpp/core/path/spline.hh
+++ b/include/hpp/core/path/spline.hh
@@ -84,6 +84,9 @@ struct sbf_traits {
 ///
 /// The dimension of control points, corresponding to the robot number of
 /// degrees of freedom can be retrieved by getter Spline::parameterSize.
+///
+/// \warning Velocities for robots with non-vector configuration space are
+/// not correctly handled.
 template <int _PolynomeBasis, int _Order>
 class HPP_CORE_DLLAPI Spline : public Path {
  public:

--- a/src/steering-method/spline.cc
+++ b/src/steering-method/spline.cc
@@ -107,22 +107,22 @@ PathPtr_t Spline<_PB, _SO>::impl_compute(
   // Compute the matrices
   // TODO calls to basisFunctionDerivative could be cached as they do not
   // depend on the inputs.
-  SplinePath::timeFreeBasisFunctionDerivative(0, 0, coeffs.row(0).transpose());
+  p->basisFunctionDerivative(0, 0, coeffs.row(0).transpose());
   pinocchio::difference<pinocchio::RnxSOnLieGroupMap>(device_.lock(), q1,
                                                       p->base(), rhs.row(0));
   for (std::size_t i = 0; i < order1.size(); ++i)
-    SplinePath::timeFreeBasisFunctionDerivative(order1[i], 0,
+    p->basisFunctionDerivative(order1[i], 0,
                                                 coeffs.row(i + 1).transpose());
   rhs.middleRows(1, order1.size()).transpose() = derivatives1;
 
   size_type row = 1 + order1.size();
-  SplinePath::timeFreeBasisFunctionDerivative(0, 1,
+  p->basisFunctionDerivative(0, 1,
                                               coeffs.row(row).transpose());
   pinocchio::difference<pinocchio::RnxSOnLieGroupMap>(device_.lock(), q2,
                                                       p->base(), rhs.row(row));
   ++row;
   for (std::size_t i = 0; i < order2.size(); ++i)
-    SplinePath::timeFreeBasisFunctionDerivative(
+    p->basisFunctionDerivative(
         order2[i], 1, coeffs.row(i + row).transpose());
   rhs.middleRows(row, order2.size()).transpose() = derivatives2;
 

--- a/src/steering-method/spline.cc
+++ b/src/steering-method/spline.cc
@@ -111,19 +111,16 @@ PathPtr_t Spline<_PB, _SO>::impl_compute(
   pinocchio::difference<pinocchio::RnxSOnLieGroupMap>(device_.lock(), q1,
                                                       p->base(), rhs.row(0));
   for (std::size_t i = 0; i < order1.size(); ++i)
-    p->basisFunctionDerivative(order1[i], 0,
-                                                coeffs.row(i + 1).transpose());
+    p->basisFunctionDerivative(order1[i], 0, coeffs.row(i + 1).transpose());
   rhs.middleRows(1, order1.size()).transpose() = derivatives1;
 
   size_type row = 1 + order1.size();
-  p->basisFunctionDerivative(0, 1,
-                                              coeffs.row(row).transpose());
+  p->basisFunctionDerivative(0, 1, coeffs.row(row).transpose());
   pinocchio::difference<pinocchio::RnxSOnLieGroupMap>(device_.lock(), q2,
                                                       p->base(), rhs.row(row));
   ++row;
   for (std::size_t i = 0; i < order2.size(); ++i)
-    p->basisFunctionDerivative(
-        order2[i], 1, coeffs.row(i + row).transpose());
+    p->basisFunctionDerivative(order2[i], 1, coeffs.row(i + row).transpose());
   rhs.middleRows(row, order2.size()).transpose() = derivatives2;
 
   // Solve the problem

--- a/tests/spline-path.cc
+++ b/tests/spline-path.cc
@@ -203,11 +203,11 @@ template <int SplineType, int Degree, int order>
 void check_steering_method() {
   typedef steeringMethod::Spline<SplineType, Degree> SM_t;
   std::vector<int> orders{1};
-  if (order == 2)
-    orders.push_back(2);
+  if (order == 2) orders.push_back(2);
 
   // Use the manipulator arm and not Romeo since steering method does not give
-  // correct values for vel/acc when the robot configuration contains a freeflyer
+  // correct values for vel/acc when the robot configuration contains a
+  // freeflyer
   DevicePtr_t dev = createRobotArm();
   BOOST_REQUIRE(dev);
   ProblemPtr_t problem = Problem::create(dev);
@@ -216,8 +216,8 @@ void check_steering_method() {
   Configuration_t q1(::pinocchio::randomConfiguration(dev->model()));
   Configuration_t q2(::pinocchio::randomConfiguration(dev->model()));
   matrix_t deriv1(matrix_t::Random(dev->numberDof(), order)),
-         deriv2(matrix_t::Random(dev->numberDof(), order));
-  double length = static_cast <float> (rand()) / static_cast <float> (RAND_MAX);
+      deriv2(matrix_t::Random(dev->numberDof(), order));
+  double length = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
 
   // Create spline
   typename SM_t::Ptr_t sm(SM_t::create(problem));
@@ -226,7 +226,8 @@ void check_steering_method() {
   // Check length
   double spline_length = spline1->length();
   BOOST_CHECK_MESSAGE(abs(spline_length - length) < 0.0001,
-      "Path does not have desired length: " << spline_length << " instead of " << length);
+                      "Path does not have desired length: "
+                          << spline_length << " instead of " << length);
 
   // Check configuration at start/end
   Configuration_t spline_q1 = spline1->initial();
@@ -235,12 +236,13 @@ void check_steering_method() {
   EIGEN_VECTOR_IS_APPROX(q2, spline_q2, 1e-6);
 
   // Check derivatives at start/end
-  for (int i=1; i <= order; i++) {
-    vector_t spline_v1(vector_t::Random(dev->numberDof())), spline_v2 = spline_v1;
+  for (int i = 1; i <= order; i++) {
+    vector_t spline_v1(vector_t::Random(dev->numberDof())),
+        spline_v2 = spline_v1;
     spline1->derivative(spline_v1, 0, i);
     spline1->derivative(spline_v2, spline_length, i);
-    EIGEN_VECTOR_IS_APPROX(deriv1.col(i-1), spline_v1, 1e-6);
-    EIGEN_VECTOR_IS_APPROX(deriv2.col(i-1), spline_v2, 1e-6);
+    EIGEN_VECTOR_IS_APPROX(deriv1.col(i - 1), spline_v1, 1e-6);
+    EIGEN_VECTOR_IS_APPROX(deriv2.col(i - 1), spline_v2, 1e-6);
   }
 }
 


### PR DESCRIPTION
The spline steering method can take as the desired path length as input (#298) but the right hand side was not updated accordingly. This fixes it and adds a test with a robotic arm robot.

Note that the same test with Romeo fails when checking the velocities because the spline steering method does not handle rotations correctly. Not sure if it should throw an exception or a warning in that case.