### PR TITLE
Improve PiecewisePolynomial

### DIFF
--- a/include/hpp/core/time-parameterization/piecewise-polynomial.hh
+++ b/include/hpp/core/time-parameterization/piecewise-polynomial.hh
@@ -146,18 +146,21 @@ class HPP_CORE_DLLAPI PiecewisePolynomial : public TimeParameterization {
   size_t findPolynomialIndex(value_type& t) const {
     size_t index;
 
-    // Points to the smallest element of breakpoints_ that is strictly greater than t
-    auto breakpointIter = std::lower_bound(breakpoints_.begin(), breakpoints_.end(), t, std::less_equal<double>());
+    // Points to the smallest element of breakpoints_ that is strictly greater
+    // than t
+    auto breakpointIter = std::lower_bound(
+        breakpoints_.begin(), breakpoints_.end(), t, std::less_equal<double>());
     if (breakpointIter == breakpoints_.begin()) {
       // t is smaller than breakpoints_[0]
       assert(t < breakpoints_[0]);
-      // Should we handle numerical issues, i.e. t is very close to breakpoints_[0] ?
+      // Should we handle numerical issues, i.e. t is very close to
+      // breakpoints_[0] ?
       index = breakpoints_.size();
     } else if (breakpointIter == breakpoints_.end()) {
       if (t > breakpoints_.back())
         index = breakpoints_.size();
-      else 
-        index = breakpoints_.size()-2;
+      else
+        index = breakpoints_.size() - 2;
     } else {
       index = std::distance(breakpoints_.begin(), breakpointIter) - 1;
     }

--- a/include/hpp/core/time-parameterization/piecewise-polynomial.hh
+++ b/include/hpp/core/time-parameterization/piecewise-polynomial.hh
@@ -59,8 +59,10 @@ class HPP_CORE_DLLAPI PiecewisePolynomial : public TimeParameterization {
    */
   PiecewisePolynomial(const ParameterMatrix_t& parameters,
                       const Vector_t& breakpoints)
-      : parameters_(parameters), breakpoints_(breakpoints) {
-    assert(breakpoints_.size() == parameters_.cols() + 1);
+      : parameters_(parameters),
+        breakpoints_(breakpoints.data(),
+                     breakpoints.data() + breakpoints.size()) {
+    assert(size_type(breakpoints_.size()) == parameters_.cols() + 1);
     assert(parameters_.rows() == NbCoeffs);
 
     for (size_type j = 0; j < parameters_.cols(); ++j) {
@@ -76,6 +78,8 @@ class HPP_CORE_DLLAPI PiecewisePolynomial : public TimeParameterization {
   }
 
   const ParameterMatrix_t& parameters() const { return parameters_; }
+
+  const std::vector<value_type>& breakpoints() const { return breakpoints_; }
 
   TimeParameterizationPtr_t copy() const {
     return TimeParameterizationPtr_t(new PiecewisePolynomial(*this));
@@ -142,6 +146,7 @@ class HPP_CORE_DLLAPI PiecewisePolynomial : public TimeParameterization {
   size_t findPolynomialIndex(value_type& t) const {
     size_t seg_index = std::numeric_limits<size_t>::max();
     for (int i = 0; i < parameters_.size(); ++i) {
+      assert(i + 1 < breakpoints_.size());
       if (breakpoints_[i] <= t && t <= breakpoints_[i + 1]) {
         seg_index = i;
         break;
@@ -163,7 +168,7 @@ class HPP_CORE_DLLAPI PiecewisePolynomial : public TimeParameterization {
   ///   number of rows = degree of polynomial + 1
   ///   number of columns = number of polynomials N
   ParameterMatrix_t parameters_;
-  Vector_t breakpoints_;  // size N + 1
+  std::vector<value_type> breakpoints_;  // size N + 1
   /// See the corresponding getter.
   bool startAtZero_ = false;
 };                        // class PiecewisePolynomial

--- a/tests/time-parameterization.cc
+++ b/tests/time-parameterization.cc
@@ -28,6 +28,7 @@
 
 #define BOOST_TEST_MODULE time_parameterization
 #include <boost/test/included/unit_test.hpp>
+#include <hpp/core/time-parameterization/piecewise-polynomial.hh>
 #include <hpp/core/time-parameterization/polynomial.hh>
 #include <hpp/pinocchio/simple-device.hh>
 #include <pinocchio/fwd.hpp>
@@ -124,6 +125,71 @@ BOOST_AUTO_TEST_CASE(degree5integration) {
     timeParameterization::Polynomial P(a);
     value_type integral = integrate(P, 1.53147);
     BOOST_CHECK_CLOSE(integral, 0.406237, prec);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(piecewise_polynomial)
+
+BOOST_AUTO_TEST_CASE(linear) {
+  typedef timeParameterization::PiecewisePolynomial<1>
+      LinearPiecewisePolynomial;
+  LinearPiecewisePolynomial::ParameterMatrix_t M(2, 2);
+  vector_t xs(3);
+  // P(x) = x + 1 for x in [0, 1]
+  // P(x) = 3 - x for x in [1, 2]
+  M << 1, 3, 1, -1;
+  xs << 0, 1, 2;
+
+  LinearPiecewisePolynomial P(M, xs);
+
+  BOOST_CHECK_THROW(P.value(-0.1), std::invalid_argument);
+  BOOST_CHECK_THROW(P.value(2.1), std::invalid_argument);
+  BOOST_CHECK_EQUAL(P.value(0), 1);
+  BOOST_CHECK_EQUAL(P.value(1), 2);
+  BOOST_CHECK_EQUAL(P.value(2), 1);
+}
+
+template <int Order>
+value_type integrate(
+    const timeParameterization::PiecewisePolynomial<Order>& P) {
+  int N = 10000;
+
+  std::vector<value_type> const& ts = P.breakpoints();
+  value_type dt = (ts.back() - ts.front()) / N;
+  value_type integral = 0;
+
+  for (int i = 0; i < N; ++i) {
+    integral += P.derivative(ts.front() + i * dt, 1) * dt;
+  }
+  return integral;
+}
+
+BOOST_AUTO_TEST_CASE(degree2integration) {
+  typedef timeParameterization::PiecewisePolynomial<2> QuadPiecewisePolynomial;
+
+  value_type prec = 0.01;  // %
+  QuadPiecewisePolynomial::ParameterMatrix_t M(3, 3);
+  vector_t ts(4);
+  ts << 0.2, 1.4, 3, 3.1;
+  {
+    M << 0, 0.408, 2.424, 0.1, 0.3, 0.2, 0.2, 0.6, 1.5;
+    QuadPiecewisePolynomial P(M, ts);
+
+    BOOST_CHECK_CLOSE(P.value(0.3),
+                      M(0, 0) + M(1, 0) * 0.3 + M(2, 0) * 0.3 * 0.3, 1e-13);
+    BOOST_CHECK_CLOSE(P.derivative(0.3, 1), M(1, 0) + 2 * M(2, 0) * 0.3, 1e-13);
+    P.polynomialsStartAtZero(true);
+    BOOST_CHECK_CLOSE(P.value(0.3),
+                      M(0, 0) + M(1, 0) * 0.1 + M(2, 0) * 0.1 * 0.1, 1e-13);
+    BOOST_CHECK_CLOSE(P.derivative(0.3, 1), M(1, 0) + 2 * M(2, 0) * 0.1, 1e-13);
+
+    for (int i : {1, 2, 3})
+      BOOST_CHECK_CLOSE(P.value(ts[i] - 1e-12), P.value(ts[i]), 1e-8);
+
+    value_type integral = integrate(P);
+    BOOST_CHECK_CLOSE(integral, P.value(ts[3]) - P.value(ts[0]), prec);
   }
 }
 


### PR DESCRIPTION
- fix a bug in `findSegmentIndex`
- add unit test
- add ability to define the individual polynomials with time starting at their index. This is useful to avoid numerical issue when both time and exponent increases.