### PR TITLE
Fix related to splines

### DIFF
--- a/src/path/hermite.cc
+++ b/src/path/hermite.cc
@@ -48,7 +48,7 @@ Hermite::Hermite(const DevicePtr_t& device, ConfigurationIn_t init,
 
   base(init);
   parameters_.row(0).setZero();
-  pinocchio::difference<hpp::pinocchio::RnxSOnLieGroupMap>(robot_, init, end,
+  pinocchio::difference<hpp::pinocchio::RnxSOnLieGroupMap>(robot_, end, init,
                                                            parameters_.row(3));
 
   projectVelocities(init, end);

--- a/src/path/spline.cc
+++ b/src/path/spline.cc
@@ -206,6 +206,8 @@ void spline_basis_function<BernsteinBasis, Degree>::bound(
     Coeffs_t& res) {
   (void)order;  // Suppress unused warning when NDEBUG
   assert(order == 1);
+  assert(0 <= t0 && t0 <= 1);
+  assert(0 <= t1 && t1 <= 1);
   static const Coeffs_t b_up = absBound(true);
   static const Coeffs_t b_um = absBound(false);
   Coeffs_t bt0, bt1;

--- a/src/path/spline.cc
+++ b/src/path/spline.cc
@@ -423,8 +423,12 @@ template <int _SplineType, int _Order>
 void Spline<_SplineType, _Order>::impl_velocityBound(
     vectorOut_t res, const value_type& t0, const value_type& t1) const {
   BasisFunctionVector_t ub;
-  BasisFunction_t::bound(1, t0, t1, ub);
-  ub /= length();
+  const value_type u0 =
+      (length() == 0 ? 0 : (t0 - paramRange().first) / paramLength());
+  const value_type u1 =
+      (length() == 0 ? 0 : (t1 - paramRange().first) / paramLength());
+  BasisFunction_t::bound(1, u0, u1, ub);
+  ub /= paramLength();
   res.noalias() = parameters_.cwiseAbs().transpose() * ub;
 }
 

--- a/src/path/spline.cc
+++ b/src/path/spline.cc
@@ -132,6 +132,7 @@ void spline_basis_function<BernsteinBasis, Degree>::eval(const value_type t,
 template <int Degree>
 void spline_basis_function<BernsteinBasis, Degree>::derivative(
     const size_type k, const value_type& t, Coeffs_t& res) {
+  assert(0 <= t && t <= 1);
   res.setZero();
   if (k > Degree) return;
   static Factorials_t factors = binomials<NbCoeffs>::factorials();

--- a/tests/spline-path.cc
+++ b/tests/spline-path.cc
@@ -29,6 +29,7 @@
 #define BOOST_TEST_MODULE spline_path
 #include <../tests/util.hh>
 #include <boost/test/included/unit_test.hpp>
+#include <hpp/core/path/hermite.hh>
 #include <hpp/core/path/spline.hh>
 #include <hpp/core/problem.hh>
 #include <hpp/core/steering-method/spline.hh>
@@ -258,4 +259,20 @@ BOOST_AUTO_TEST_CASE(steering_method) {
   check_steering_method<path::BernsteinBasis, 3, 1>();
   check_steering_method<path::BernsteinBasis, 5, 1>();
   check_steering_method<path::BernsteinBasis, 5, 2>();
+}
+
+BOOST_AUTO_TEST_CASE(hermite_path) {
+  DevicePtr_t dev = createRobotArm();
+  ConstraintSetPtr_t constraint =
+      hpp::core::ConstraintSet::create(dev, "empty");
+
+  vector_t q1(vector_t::Zero(dev->configSize()));
+  vector_t q2(vector_t::Ones(dev->configSize()));
+
+  path::HermitePtr_t path =
+      hpp::core::path::Hermite::create(dev, q1, q2, constraint);
+  bool ok;
+  vector_t evaluated = path->eval(path->length(), ok);
+  BOOST_CHECK(ok);
+  CONFIGURATION_VECTOR_IS_APPROX(dev, evaluated, path->end(), 1e-12);
 }


### PR DESCRIPTION
Fix bugs in `path::Hermite` and `path::Spline::impl_velocityBound`.

The first commit adds
- a failing test case for `path::Hermite`
- and a failing assert for `path::Spline::impl_velocityBound`.

The following commits fix the issues.