### PR TITLE
Improve performances of continuous path validation

### DIFF
--- a/include/hpp/core/continuous-validation.hh
+++ b/include/hpp/core/continuous-validation.hh
@@ -211,6 +211,14 @@ class HPP_CORE_DLLAPI ContinuousValidation : public PathValidation,
   /// Get tolerance value
   value_type tolerance() const { return tolerance_; }
 
+  /// Get the break distance passed to collision checking.
+  /// \sa hpp::fcl::CollisionRequest::break_distance
+  value_type breakDistance() const { return breakDistance_; }
+
+  /// Set the break distance passed to collision checking.
+  /// \sa value_type breakDistance() const
+  void breakDistance(value_type distance);
+
   DevicePtr_t robot() const { return robot_; }
   /// Iteratively call method doExecute of delegate classes Initialize
   /// \sa ContinuousValidation::add, ContinuousValidation::Initialize.
@@ -291,6 +299,7 @@ class HPP_CORE_DLLAPI ContinuousValidation : public PathValidation,
 
   DevicePtr_t robot_;
   value_type tolerance_;
+  value_type breakDistance_;
 
   /// Store weak pointer to itself.
   void init(ContinuousValidationWkPtr_t weak);

--- a/include/hpp/core/continuous-validation/solid-solid-collision.hh
+++ b/include/hpp/core/continuous-validation/solid-solid-collision.hh
@@ -80,6 +80,10 @@ class HPP_CORE_DLLAPI SolidSolidCollision : public BodyPairCollision {
 
   bool removeObjectTo_b(const CollisionObjectConstPtr_t& object);
 
+  /// Set the break distance of each hpp::fcl::CollisionRequest
+  /// \sa void ContinuousValidation::breakDistance(value_type) const
+  void breakDistance(value_type distance);
+
   std::string name() const;
 
   std::ostream& print(std::ostream& os) const;

--- a/src/continuous-validation/solid-solid-collision.cc
+++ b/src/continuous-validation/solid-solid-collision.cc
@@ -121,6 +121,11 @@ bool SolidSolidCollision::removeObjectTo_b(
   return last != s;
 }
 
+void SolidSolidCollision::breakDistance(value_type breakDistance) {
+  for (fcl::CollisionRequest& req : requests())
+    req.break_distance = breakDistance;
+}
+
 void SolidSolidCollision::addCollisionPair(
     const CollisionObjectConstPtr_t& left,
     const CollisionObjectConstPtr_t& right) {

--- a/src/weighed-distance.cc
+++ b/src/weighed-distance.cc
@@ -253,7 +253,7 @@ void WeighedDistance::computeWeights() {
       }
     }
   }
-  hppDout(info, "The weights are " << weights_);
+  hppDout(info, "The weights are " << weights_.transpose());
 }
 
 WeighedDistance::WeighedDistance(const DevicePtr_t& robot)


### PR DESCRIPTION
- Add the ability to tune the break distance. In my experiments, there were many occurrence of the distance lower bound being very close to the break distance while the objects where further apart. Having a distance lower bound of 1mm (the default break distance) means we do a lot of (very) small iterations.
- Refine the velocity bound twice instead of just once. The number of iterations is arguable. I just noticed a substantial improvement when doing this. I haven't tried with more iterations.
- Added a few debug output.