### PR TITLE
Add seedable uniform configuration shooter.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ set(${PROJECT_NAME}_HEADERS
     include/hpp/core/projection-error.hh
     include/hpp/core/configuration-shooter.hh
     include/hpp/core/configuration-shooter/uniform.hh
+    include/hpp/core/configuration-shooter/uniform-tpl.hh
+    include/hpp/core/configuration-shooter/uniform-tpl.hxx
     include/hpp/core/configuration-shooter/gaussian.hh
     include/hpp/core/config-projector.hh
     include/hpp/core/config-validation.hh
@@ -155,6 +157,7 @@ set(${PROJECT_NAME}_SOURCES
     src/bi-rrt-planner.cc
     src/collision-validation.cc
     src/configuration-shooter/uniform.cc
+    src/configuration-shooter/uniform-tpl.cc
     src/configuration-shooter/gaussian.cc
     src/config-projector.cc
     src/config-validations.cc

--- a/include/hpp/core/configuration-shooter/uniform-tpl.hh
+++ b/include/hpp/core/configuration-shooter/uniform-tpl.hh
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Eureka Robotics
+// Authors: Joseph Mirabel
+
+#ifndef HPP_CORE_CONFIGURATION_SHOOTER_UNIFORM_TPL_HH
+#define HPP_CORE_CONFIGURATION_SHOOTER_UNIFORM_TPL_HH
+
+#include <hpp/core/configuration-shooter.hh>
+#include <hpp/pinocchio/device.hh>
+#include <random>
+
+namespace hpp {
+namespace core {
+namespace configurationShooter {
+
+/// \addtogroup configuration_sampling
+/// \{
+
+/// Uniformly sample with bounds of degrees of freedom using a custom generator.
+template<class generator_t>
+class HPP_CORE_DLLAPI UniformTpl : public ConfigurationShooter {
+ public:
+  typedef shared_ptr<UniformTpl<generator_t>> Ptr_t;
+  typedef weak_ptr<UniformTpl<generator_t>> WkPtr_t;
+
+  static Ptr_t create(const DevicePtr_t& robot) {
+    UniformTpl* ptr = new UniformTpl(robot);
+    Ptr_t shPtr(ptr);
+    ptr->init(shPtr);
+    return shPtr;
+  }
+
+  /// Set the generator seed.
+  void seed(typename generator_t::result_type seed) {
+    generator_.seed(seed);
+  }
+
+ protected:
+  /// Uniformly sample configuration space
+  ///
+  /// Note that translation joints have to be bounded.
+  UniformTpl(const DevicePtr_t& robot) : robot_(robot) {}
+  void init(const Ptr_t& self) {
+    ConfigurationShooter::init(self);
+    weak_ = self;
+  }
+
+  virtual void impl_shoot(Configuration_t& q) const;
+
+ private:
+  DevicePtr_t robot_;
+  WkPtr_t weak_;
+
+  // The generator must be mutable because impl_shoot is const and
+  // generator_t::operator() is not.
+  mutable generator_t generator_;
+};  // class UniformTpl
+/// \}
+
+typedef UniformTpl<std::default_random_engine> UniformSeedable;
+
+}  // namespace configurationShooter
+}  //   namespace core
+}  // namespace hpp
+
+#endif  // HPP_CORE_CONFIGURATION_SHOOTER_UNIFORM_TPL_HH

--- a/include/hpp/core/configuration-shooter/uniform-tpl.hh
+++ b/include/hpp/core/configuration-shooter/uniform-tpl.hh
@@ -16,7 +16,7 @@ namespace configurationShooter {
 /// \{
 
 /// Uniformly sample with bounds of degrees of freedom using a custom generator.
-template<class generator_t>
+template <class generator_t>
 class HPP_CORE_DLLAPI UniformTpl : public ConfigurationShooter {
  public:
   typedef shared_ptr<UniformTpl<generator_t>> Ptr_t;
@@ -30,9 +30,7 @@ class HPP_CORE_DLLAPI UniformTpl : public ConfigurationShooter {
   }
 
   /// Set the generator seed.
-  void seed(typename generator_t::result_type seed) {
-    generator_.seed(seed);
-  }
+  void seed(typename generator_t::result_type seed) { generator_.seed(seed); }
 
  protected:
   /// Uniformly sample configuration space

--- a/include/hpp/core/configuration-shooter/uniform-tpl.hxx
+++ b/include/hpp/core/configuration-shooter/uniform-tpl.hxx
@@ -5,20 +5,20 @@
 #define HPP_CORE_CONFIGURATION_SHOOTER_UNIFORM_TPL_HXX
 
 #include <hpp/core/configuration-shooter/uniform-tpl.hh>
-
-#include <pinocchio/multibody/model.hpp>
 #include <hpp/pinocchio/liegroup-space.hh>
+#include <pinocchio/multibody/model.hpp>
 
 namespace hpp {
 namespace core {
 namespace configurationShooter {
 
-template<class generator_t>
+template <class generator_t>
 void UniformTpl<generator_t>::impl_shoot(Configuration_t& config) const {
   typedef std::uniform_real_distribution<value_type> distribution_t;
 
   if (!robot_->configSpace()->isVectorSpace()) {
-    throw std::invalid_argument("The device config space must be a vector space"
+    throw std::invalid_argument(
+        "The device config space must be a vector space"
         " to use UniformTpl");
   }
 
@@ -26,7 +26,8 @@ void UniformTpl<generator_t>::impl_shoot(Configuration_t& config) const {
   auto const& model = robot_->model();
 
   for (size_type i = 0; i < model.nq; ++i) {
-    distribution_t distrib(model.lowerPositionLimit[i], model.upperPositionLimit[i]);
+    distribution_t distrib(model.lowerPositionLimit[i],
+                           model.upperPositionLimit[i]);
     config[i] = distrib(generator_);
   }
   auto const& ecs = robot_->extraConfigSpace();

--- a/include/hpp/core/configuration-shooter/uniform-tpl.hxx
+++ b/include/hpp/core/configuration-shooter/uniform-tpl.hxx
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 Eureka Robotics
+// Authors: Joseph Mirabel
+
+#ifndef HPP_CORE_CONFIGURATION_SHOOTER_UNIFORM_TPL_HXX
+#define HPP_CORE_CONFIGURATION_SHOOTER_UNIFORM_TPL_HXX
+
+#include <hpp/core/configuration-shooter/uniform-tpl.hh>
+
+#include <pinocchio/multibody/model.hpp>
+#include <hpp/pinocchio/liegroup-space.hh>
+
+namespace hpp {
+namespace core {
+namespace configurationShooter {
+
+template<class generator_t>
+void UniformTpl<generator_t>::impl_shoot(Configuration_t& config) const {
+  typedef std::uniform_real_distribution<value_type> distribution_t;
+
+  if (!robot_->configSpace()->isVectorSpace()) {
+    throw std::invalid_argument("The device config space must be a vector space"
+        " to use UniformTpl");
+  }
+
+  config.resize(robot_->configSize());
+  auto const& model = robot_->model();
+
+  for (size_type i = 0; i < model.nq; ++i) {
+    distribution_t distrib(model.lowerPositionLimit[i], model.upperPositionLimit[i]);
+    config[i] = distrib(generator_);
+  }
+  auto const& ecs = robot_->extraConfigSpace();
+  for (size_type i = 0; i < ecs.dimension(); ++i) {
+    distribution_t distrib(ecs.lower(i), ecs.upper(i));
+    config[model.nq + i] = distrib(generator_);
+  }
+}
+
+}  // namespace configurationShooter
+}  // namespace core
+}  // namespace hpp
+
+#endif  // HPP_CORE_CONFIGURATION_SHOOTER_UNIFORM_TPL_HXX

--- a/src/configuration-shooter/uniform-tpl.cc
+++ b/src/configuration-shooter/uniform-tpl.cc
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 Eureka Robotics
+// Authors: Joseph Mirabel
+
+#include <hpp/core/configuration-shooter/uniform-tpl.hh>
+#include <hpp/core/configuration-shooter/uniform-tpl.hxx>
+
+namespace hpp {
+namespace core {
+namespace configurationShooter {
+
+template class UniformTpl<std::default_random_engine>;
+
+}  // namespace configurationShooter
+}  // namespace core
+}  // namespace hpp

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -38,6 +38,7 @@
 #include <hpp/core/config-projector.hh>
 #include <hpp/core/configuration-shooter/gaussian.hh>
 #include <hpp/core/configuration-shooter/uniform.hh>
+#include <hpp/core/configuration-shooter/uniform-tpl.hh>
 #include <hpp/core/constraint-set.hh>
 #include <hpp/core/continuous-validation/dichotomy.hh>
 #include <hpp/core/continuous-validation/progressive.hh>
@@ -149,6 +150,14 @@ configurationShooter::UniformPtr_t createUniformConfigShooter(
   return ptr;
 }
 
+template<class generator_t>
+typename configurationShooter::UniformTpl<generator_t>::Ptr_t createUniformTpl(
+    const ProblemConstPtr_t& p) {
+  typedef configurationShooter::UniformTpl<generator_t> shooter_t;
+  typename shooter_t::Ptr_t ptr(shooter_t::create(p->robot()));
+  return ptr;
+}
+
 ProblemSolverPtr_t ProblemSolver::create() {
   return ProblemSolverPtr_t(new ProblemSolver());
 }
@@ -203,6 +212,7 @@ ProblemSolver::ProblemSolver()
 
   configurationShooters.add("Uniform", createUniformConfigShooter);
   configurationShooters.add("Gaussian", createGaussianConfigShooter);
+  configurationShooters.add("UniformSeedable", createUniformTpl<std::default_random_engine>);
 
   distances.add("Weighed", WeighedDistance::createFromProblem);
   distances.add(

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -37,8 +37,8 @@
 #include <hpp/core/collision-validation.hh>
 #include <hpp/core/config-projector.hh>
 #include <hpp/core/configuration-shooter/gaussian.hh>
-#include <hpp/core/configuration-shooter/uniform.hh>
 #include <hpp/core/configuration-shooter/uniform-tpl.hh>
+#include <hpp/core/configuration-shooter/uniform.hh>
 #include <hpp/core/constraint-set.hh>
 #include <hpp/core/continuous-validation/dichotomy.hh>
 #include <hpp/core/continuous-validation/progressive.hh>
@@ -150,7 +150,7 @@ configurationShooter::UniformPtr_t createUniformConfigShooter(
   return ptr;
 }
 
-template<class generator_t>
+template <class generator_t>
 typename configurationShooter::UniformTpl<generator_t>::Ptr_t createUniformTpl(
     const ProblemConstPtr_t& p) {
   typedef configurationShooter::UniformTpl<generator_t> shooter_t;
@@ -212,7 +212,8 @@ ProblemSolver::ProblemSolver()
 
   configurationShooters.add("Uniform", createUniformConfigShooter);
   configurationShooters.add("Gaussian", createGaussianConfigShooter);
-  configurationShooters.add("UniformSeedable", createUniformTpl<std::default_random_engine>);
+  configurationShooters.add("UniformSeedable",
+                            createUniformTpl<std::default_random_engine>);
 
   distances.add("Weighed", WeighedDistance::createFromProblem);
   distances.add(

--- a/tests/configuration-shooters.cc
+++ b/tests/configuration-shooters.cc
@@ -29,8 +29,8 @@
 #define BOOST_TEST_MODULE configuration_shooters
 #include <boost/test/included/unit_test.hpp>
 #include <hpp/core/configuration-shooter/gaussian.hh>
-#include <hpp/core/configuration-shooter/uniform.hh>
 #include <hpp/core/configuration-shooter/uniform-tpl.hh>
+#include <hpp/core/configuration-shooter/uniform.hh>
 #include <hpp/pinocchio/configuration.hh>
 #include <hpp/pinocchio/device.hh>
 #include <hpp/pinocchio/simple-device.hh>
@@ -44,13 +44,13 @@ using namespace hpp::core::configurationShooter;
 
 namespace pin_test = hpp::pinocchio::unittest;
 
-
 hpp::pinocchio::DevicePtr_t makeDevice() {
   using namespace hpp::pinocchio;
 
   DevicePtr_t device = Device::create("test");
   urdf::loadModelFromString(device, 0, "", "prismatic_x",
-      "<robot name='n'><link name='base_link'/></robot>", "");
+                            "<robot name='n'><link name='base_link'/></robot>",
+                            "");
 
   return device;
 }
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(uniform_seedable) {
 
   hpp::core::Configuration_t q;
 
-  hpp::core::vector_t shoots (100);
+  hpp::core::vector_t shoots(100);
 
   shooter->seed(0);
   for (int i = 0; i < shoots.size(); ++i) {


### PR DESCRIPTION
Fixes #324

The current implementation works only for vector spaces and not for general lie groups.