### PR TITLE
Fix computation of valid interval in BodyPairCollision

### DIFF
--- a/src/continuous-validation/body-pair-collision.cc
+++ b/src/continuous-validation/body-pair-collision.cc
@@ -171,10 +171,8 @@ value_type BodyPairCollision::collisionFreeInterval(
       Vm[i + 1] = computeMaximalVelocity(Vb_);
       T[i + 1] = distanceLowerBound / Vm[i + 1];
       if (i % 2 == 1) {
-        assert(T[i + 1] >= T[i]);
-        assert(Vm[i + 1] <= Vm[i]);
-        assert(T[i + 2] <= T[i + 1]);
-        assert(Vm[i + 2] >= Vm[i + 1]);
+        assert(T[i-1] <= T[i+1] && T[i+1] <= T[i]);
+        assert(Vm[i-1] >= Vm[i+1] && Vm[i+1] >= Vm[i]);
       }
     }
     constexpr int k = 2 * Nrefine;

--- a/src/continuous-validation/body-pair-collision.cc
+++ b/src/continuous-validation/body-pair-collision.cc
@@ -171,8 +171,8 @@ value_type BodyPairCollision::collisionFreeInterval(
       Vm[i + 1] = computeMaximalVelocity(Vb_);
       T[i + 1] = distanceLowerBound / Vm[i + 1];
       if (i % 2 == 1) {
-        assert(T[i-1] <= T[i+1] && T[i+1] <= T[i]);
-        assert(Vm[i-1] >= Vm[i+1] && Vm[i+1] >= Vm[i]);
+        assert(T[i - 1] <= T[i + 1] && T[i + 1] <= T[i]);
+        assert(Vm[i - 1] >= Vm[i + 1] && Vm[i + 1] >= Vm[i]);
       }
     }
     constexpr int k = 2 * Nrefine;

--- a/src/continuous-validation/body-pair-collision.cc
+++ b/src/continuous-validation/body-pair-collision.cc
@@ -171,10 +171,10 @@ value_type BodyPairCollision::collisionFreeInterval(
       Vm[i + 1] = computeMaximalVelocity(Vb_);
       T[i + 1] = distanceLowerBound / Vm[i + 1];
       if (i % 2 == 1) {
-        assert(T[i+1] >= T[i]);
-        assert(Vm[i+1] <= Vm[i]);
-        assert(T[i+2] <= T[i+1]);
-        assert(Vm[i+2] >= Vm[i+1]);
+        assert(T[i + 1] >= T[i]);
+        assert(Vm[i + 1] <= Vm[i]);
+        assert(T[i + 2] <= T[i + 1]);
+        assert(Vm[i + 2] >= Vm[i + 1]);
       }
     }
     constexpr int k = 2 * Nrefine;

--- a/src/diffusing-planner.cc
+++ b/src/diffusing-planner.cc
@@ -104,7 +104,7 @@ PathPtr_t DiffusingPlanner::extend(const NodePtr_t& near,
     if (configProjector) {
       assert(isNormalized(problem()->robot(), target,
                           PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE));
-      assert(isNormalized(problem()->robot(), *(near->configuration()),
+      assert(isNormalized(problem()->robot(), near->configuration(),
                           PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE));
       configProjector->projectOnKernel(near->configuration(), target, qProj_);
       assert(isNormalized(problem()->robot(), qProj_,

--- a/src/node.cc
+++ b/src/node.cc
@@ -74,8 +74,8 @@ void Node::addInEdge(EdgePtr_t edge) {
           "Attempt to insert an edge between two nodes already connected");
       hppDout(error, msg.c_str());
       hppDout(error,
-              "from: " << (*(edge->from()->configuration())).transpose());
-      hppDout(error, "  to: " << (*configuration_).transpose());
+              "from: " << (edge->from()->configuration()).transpose());
+      hppDout(error, "  to: " << configuration_.transpose());
       throw std::runtime_error(msg.c_str());
     }
   }

--- a/src/node.cc
+++ b/src/node.cc
@@ -73,8 +73,7 @@ void Node::addInEdge(EdgePtr_t edge) {
       std::string msg(
           "Attempt to insert an edge between two nodes already connected");
       hppDout(error, msg.c_str());
-      hppDout(error,
-              "from: " << (edge->from()->configuration()).transpose());
+      hppDout(error, "from: " << (edge->from()->configuration()).transpose());
       hppDout(error, "  to: " << configuration_.transpose());
       throw std::runtime_error(msg.c_str());
     }

--- a/src/path-projector/progressive.cc
+++ b/src/path-projector/progressive.cc
@@ -263,7 +263,7 @@ bool Progressive::project(const PathPtr_t& path, PathPtr_t& proj) const {
   bool success;
   Configuration_t q = proj->eval(proj->timeRange().second, success);
   if (!success) {
-    q = (*proj)(proj->timeRange().second, success);
+    q = proj->eval(proj->timeRange().second, success);
   }
   assert(success);
   vector_t error;


### PR DESCRIPTION
When compiling and running the tests in debug mode, an assert was raised in the continuous validation.
This PR fixes the computation of the valid interval and other minor compilation errors that show up in debug mode.

