### PR TITLE
Use proxqp instead of eiquadprog for solving QP programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,11 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake-modules/ ${CMAKE_MODULE_PATH})
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)
 project(${PROJECT_NAME} ${PROJECT_ARGS})
 
-add_project_dependency(hpp-pinocchio)
-add_project_dependency(hpp-util)
-add_project_dependency(hpp-statistics)
-add_project_dependency(hpp-constraints)
-add_project_dependency(proxsuite)
+add_project_dependency(hpp-pinocchio REQUIRED)
+add_project_dependency(hpp-util REQUIRED)
+add_project_dependency(hpp-statistics REQUIRED)
+add_project_dependency(hpp-constraints REQUIRED)
+add_project_dependency(proxsuite REQUIRED)
 
 find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_project_dependency(hpp-pinocchio)
 add_project_dependency(hpp-util)
 add_project_dependency(hpp-statistics)
 add_project_dependency(hpp-constraints)
+add_project_dependency(proxsuite)
 
 find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 

--- a/include/hpp/core/path-optimization/quadratic-program.hh
+++ b/include/hpp/core/path-optimization/quadratic-program.hh
@@ -72,7 +72,7 @@ struct QuadraticProgram {
       : H(inputSize, inputSize),
         b(inputSize),
         dec(inputSize, inputSize, Eigen::ComputeThinU | Eigen::ComputeThinV),
-        xStar(inputSize), useProxqp_(useProxqp) {
+        xStar(inputSize), accuracy_(1e-4), useProxqp_(useProxqp) {
     H.setZero();
     b.setZero();
     bIsZero = true;
@@ -92,16 +92,31 @@ struct QuadraticProgram {
         bIsZero(false),
         dec(lc.PK.cols(), lc.PK.cols(),
             Eigen::ComputeThinU | Eigen::ComputeThinV),
-        xStar(lc.PK.cols()), useProxqp_(useProxqp) {
+        xStar(lc.PK.cols()), accuracy_(1e-4), useProxqp_(useProxqp) {
     QP.reduced(lc, *this);
   }
 
   QuadraticProgram(const QuadraticProgram& QP)
     : H(QP.H), b(QP.b), bIsZero(QP.bIsZero), dec(QP.dec), xStar(QP.xStar),
-    useProxqp_(QP.useProxqp_) {}
+      accuracy_(QP.accuracy_), useProxqp_(QP.useProxqp_) {}
 
   ~QuadraticProgram();
 
+  /// Set accuracy of internal QP solver
+  /// \param acc the desired accuracy
+  /// \note only used by proxqp
+  /// The accuracy corresponds to \f$\epsilon_{abs}\f$ in \link
+  /// https://inria.hal.science/hal-03683733/file/Yet_another_QP_solver_for_robotics_and_beyond.pdf this paper \endlink (Equation (2)).
+  void accuracy(value_type acc) {
+    accuracy_ = acc;
+  }
+  /// Get accuracy of internal QP solver
+  /// \note only used by proxqp
+  /// The accuracy corresponds to \f$\epsilon_{abs}\f$ in \link
+  /// https://inria.hal.science/hal-03683733/file/Yet_another_QP_solver_for_robotics_and_beyond.pdf this paper \endlink (Equation (2)).
+  value_type accuracy() const {
+    return accuracy_;
+  }
   void addRows(const std::size_t& nbRows) {
     H.conservativeResize(H.rows() + nbRows, H.cols());
     b.conservativeResize(b.rows() + nbRows, b.cols());
@@ -170,6 +185,7 @@ struct QuadraticProgram {
   Decomposition_t dec;
   vector_t xStar;
   /// \}
+  value_type accuracy_;
   bool useProxqp_;
 };
 }  // namespace pathOptimization

--- a/include/hpp/core/path-optimization/quadratic-program.hh
+++ b/include/hpp/core/path-optimization/quadratic-program.hh
@@ -37,7 +37,7 @@ namespace core {
 /// \addtogroup path_optimization
 /// \{
 namespace pathOptimization {
-  /** Quadratic program
+/** Quadratic program
  *
  *  This class stores a quadratic cost defined by
  *  \f$ \frac{1}{2} x^T H x + b^T x \f$ where \f$ (H, b) \f$ are the parameters.
@@ -68,11 +68,13 @@ struct QuadraticProgram {
   /// \param useProxqp whether to use proxqp instead of eiquadprog_2011 as
   ///                  the internal solver. This parameter will soon be removed
   ///                  and proxqp be the internal solver.
-  QuadraticProgram(size_type inputSize, bool useProxqp=true)
+  QuadraticProgram(size_type inputSize, bool useProxqp = true)
       : H(inputSize, inputSize),
         b(inputSize),
         dec(inputSize, inputSize, Eigen::ComputeThinU | Eigen::ComputeThinV),
-        xStar(inputSize), accuracy_(1e-4), useProxqp_(useProxqp) {
+        xStar(inputSize),
+        accuracy_(1e-4),
+        useProxqp_(useProxqp) {
     H.setZero();
     b.setZero();
     bIsZero = true;
@@ -86,19 +88,26 @@ struct QuadraticProgram {
   ///                  the internal solver. This parameter will soon be removed
   ///                  and proxqp be the internal solver.
   QuadraticProgram(const QuadraticProgram& QP, const LinearConstraint& lc,
-                   bool useProxqp=true)
+                   bool useProxqp = true)
       : H(lc.PK.cols(), lc.PK.cols()),
         b(lc.PK.cols()),
         bIsZero(false),
         dec(lc.PK.cols(), lc.PK.cols(),
             Eigen::ComputeThinU | Eigen::ComputeThinV),
-        xStar(lc.PK.cols()), accuracy_(1e-4), useProxqp_(useProxqp) {
+        xStar(lc.PK.cols()),
+        accuracy_(1e-4),
+        useProxqp_(useProxqp) {
     QP.reduced(lc, *this);
   }
 
   QuadraticProgram(const QuadraticProgram& QP)
-    : H(QP.H), b(QP.b), bIsZero(QP.bIsZero), dec(QP.dec), xStar(QP.xStar),
-      accuracy_(QP.accuracy_), useProxqp_(QP.useProxqp_) {}
+      : H(QP.H),
+        b(QP.b),
+        bIsZero(QP.bIsZero),
+        dec(QP.dec),
+        xStar(QP.xStar),
+        accuracy_(QP.accuracy_),
+        useProxqp_(QP.useProxqp_) {}
 
   ~QuadraticProgram();
 
@@ -106,17 +115,15 @@ struct QuadraticProgram {
   /// \param acc the desired accuracy
   /// \note only used by proxqp
   /// The accuracy corresponds to \f$\epsilon_{abs}\f$ in \link
-  /// https://inria.hal.science/hal-03683733/file/Yet_another_QP_solver_for_robotics_and_beyond.pdf this paper \endlink (Equation (2)).
-  void accuracy(value_type acc) {
-    accuracy_ = acc;
-  }
+  /// https://inria.hal.science/hal-03683733/file/Yet_another_QP_solver_for_robotics_and_beyond.pdf
+  /// this paper \endlink (Equation (2)).
+  void accuracy(value_type acc) { accuracy_ = acc; }
   /// Get accuracy of internal QP solver
   /// \note only used by proxqp
   /// The accuracy corresponds to \f$\epsilon_{abs}\f$ in \link
-  /// https://inria.hal.science/hal-03683733/file/Yet_another_QP_solver_for_robotics_and_beyond.pdf this paper \endlink (Equation (2)).
-  value_type accuracy() const {
-    return accuracy_;
-  }
+  /// https://inria.hal.science/hal-03683733/file/Yet_another_QP_solver_for_robotics_and_beyond.pdf
+  /// this paper \endlink (Equation (2)).
+  value_type accuracy() const { return accuracy_; }
   void addRows(const std::size_t& nbRows) {
     H.conservativeResize(H.rows() + nbRows, H.cols());
     b.conservativeResize(b.rows() + nbRows, b.cols());

--- a/include/hpp/core/path-optimization/quadratic-program.hh
+++ b/include/hpp/core/path-optimization/quadratic-program.hh
@@ -37,23 +37,23 @@ namespace core {
 /// \addtogroup path_optimization
 /// \{
 namespace pathOptimization {
-/*/ Quadratic program
+  /** Quadratic program
  *
  *  This class stores a quadratic cost defined by
- *  \f$ 0.5 * x^T H x + b^T x \f$ where \f$ (H, b) \f$ are the parameters.
+ *  \f$ \frac{1}{2} x^T H x + b^T x \f$ where \f$ (H, b) \f$ are the parameters.
  *
  *  It can then solve the two following program:
  *  \li Program subject to linear equality constraints
  *  \f{eqnarray*}{
- *  min & 0.5 * x^T H x + b^T x \\
- *      & A_0 * x = b_0
+ *  \min & \frac{1}{2} x^T H x + b^T x \\
+ *      A_0 x = b_0
  *  \f}
  *  This is done via \ref reduced, \ref decompose and \ref solve methods
  *  \li Program subject to linear equality and inequality constraints:
  *  \f{eqnarray*}{
- *  min & 0.5 * x^T H x + b^T x \\
- *      & A_0 * x  =  b_0 \\
- *      & A_1 * x \ge b_1
+ *  \min & \frac{1}{2} x^T H x + b^T x \\
+ *      A_0 x  =  b_0 \\
+ *      A_1 x \ge b_1
  *  \f}
  *  This is done via \ref computeLLT and \ref solve methods
  *  and uses quadprog
@@ -99,8 +99,8 @@ struct QuadraticProgram {
 
   /*/ Compute the problem
    *  \f{eqnarray*}{
-   *  min & 0.5 * x^T H x + b^T x \\
-   *      & lc.J * x = lc.b
+   *  \min & \frac{1}{2} * x^T H x + b^T x \\
+   *      lc.J * x = lc.b
    *  \f}
    **/
   void reduced(const LinearConstraint& lc, QuadraticProgram& QPr) const {

--- a/src/continuous-validation/body-pair-collision.cc
+++ b/src/continuous-validation/body-pair-collision.cc
@@ -26,8 +26,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 // DAMAGE.
 
-#define HPP_DEBUG 1
-
 #include <hpp/fcl/collision.h>
 #include <hpp/fcl/collision_data.h>
 

--- a/src/continuous-validation/body-pair-collision.cc
+++ b/src/continuous-validation/body-pair-collision.cc
@@ -127,7 +127,7 @@ value_type BodyPairCollision::collisionFreeInterval(
   Vm[0] = maxVelocity = maximalVelocity_;
   T[0] = distanceLowerBound / maxVelocity;
   if (!refine_) {
-    if (T[0] < 1e-3) {
+    if (T[0] < 1e-3 && T[0] != 0) {
       hppDout(notice,
               "Small interval without refine: "
               "maxVelocity = "

--- a/src/path-optimization/quadratic-program.cc
+++ b/src/path-optimization/quadratic-program.cc
@@ -26,8 +26,10 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 // DAMAGE.
 
+#include <iostream>
 #include <hpp/core/path-optimization/quadratic-program.hh>
 #include <hpp/util/timer.hh>
+#include <proxsuite/proxqp/dense/wrapper.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
@@ -69,14 +71,15 @@ double QuadraticProgram::solve(const LinearConstraint& ce,
     throw std::runtime_error(
         "The QP is over-constrained. QuadProg cannot handle it.");
   HPP_SCOPE_TIMECOUNTER(QuadraticProgram_solve_quadprog);
-  // min   0.5 * x G x + g0 x
-  // s.t.  CE^T x + ce0 = 0
-  //       CI^T x + ci0 >= 0
-  Eigen::QuadProgStatus status;
-  double cost =
+  // min   0.5 * x H x + g x
+  // s.t.  CE x + ce0 = 0
+  //       CI x + ci0 >= 0
+  if (!useProxqp_) {
+    Eigen::QuadProgStatus status;
+    double cost =
       solve_quadprog2(llt, trace, b, ce.J.transpose(), -ce.b, ci.J.transpose(),
                       -ci.b, xStar, activeConstraint, activeSetSize, status);
-  switch (status) {
+    switch (status) {
     case Eigen::UNBOUNDED:
       hppDout(warning, "Quadratic problem is not bounded");
     case Eigen::CONVERGED:
@@ -84,8 +87,48 @@ double QuadraticProgram::solve(const LinearConstraint& ce,
     case Eigen::CONSTRAINT_LINEARLY_DEPENDENT:
       hppDout(error, "Constraint of quadratic problem are linearly dependent.");
       break;
+    }
+    return cost;
+  } else {
+    using proxsuite::proxqp::QPSolverOutput;
+    proxsuite::proxqp::dense::QP<value_type> qp{H.rows(), ce.b.size(),
+                                                ci.b.size()};
+    qp.settings.eps_abs = accuracy_;
+    vector_t u = ci.b;
+    u.fill(std::numeric_limits<value_type>::infinity());
+
+    qp.init(H, b, ce.J, ce.b, ci.J, ci.b, u);
+    qp.solve();
+    value_type res(0);
+    Eigen::IOFormat fullPrecision(Eigen::FullPrecision, Eigen::DontAlignCols,
+                                  ", ", ", ", "", "", " << ", ";");
+    switch(qp.results.info.status){
+    case QPSolverOutput::PROXQP_SOLVED:
+      xStar = qp.results.x;
+      res += (.5*xStar.transpose()*H*xStar)(0,0);
+      res += (b.transpose()*xStar)(0);
+      return res;
+      break;
+    case QPSolverOutput::PROXQP_MAX_ITER_REACHED:
+      hppDout(warning, "PROXQP_MAX_ITER_REACHED");
+      break;
+    case QPSolverOutput::PROXQP_PRIMAL_INFEASIBLE:
+      hppDout(warning, "PROXQP_PRIMAL_INFEASIBLE");
+      break;
+    case QPSolverOutput::PROXQP_SOLVED_CLOSEST_PRIMAL_FEASIBLE:
+      hppDout(warning, "PROXQP_SOLVED_CLOSEST_PRIMAL_FEASIBLE");
+      break;
+    case QPSolverOutput::PROXQP_DUAL_INFEASIBLE:
+      hppDout(warning, "PROXQP_DUAL_INFEASIBLE");
+      break;
+    case QPSolverOutput::PROXQP_NOT_RUN:
+      hppDout(warning, "PROXQP_NOT_RUN");
+      break;
+    default:
+      abort();
+    }
   }
-  return cost;
+  return std::numeric_limits<value_type>::infinity();
 }
 }  // namespace pathOptimization
 }  // namespace core

--- a/src/path-optimization/spline-gradient-based-abstract.cc
+++ b/src/path-optimization/spline-gradient-based-abstract.cc
@@ -427,6 +427,8 @@ void SplineGradientBasedAbstract<_PB, _SO>::jointBoundConstraint(
 
   matrix_t A(2 * rDof, rDof);
   vector_t b(2 * rDof);
+  // Only the number of inequality constraints (rows) is used after this
+  // call. Matrix A and vector b are not used, only resized.
   const size_type rows =
       jointBoundMatrices(robot_, robot_->neutralConfiguration(), A, b);
 

--- a/src/path-optimization/spline-gradient-based.cc
+++ b/src/path-optimization/spline-gradient-based.cc
@@ -403,9 +403,9 @@ PathVectorPtr_t SplineGradientBased<_PB, _SO>::optimize(
   value_type costThreshold =
       problem()->getParameter("SplineGradientBased/costThreshold").floatValue();
   bool useProxqp =
-    problem()->getParameter("SplineGradientBased/useProxqp").boolValue();
-  value_type eps_abs(problem()->getParameter("SplineGradientBased/QPAccuracy").
-                     floatValue());
+      problem()->getParameter("SplineGradientBased/useProxqp").boolValue();
+  value_type eps_abs(
+      problem()->getParameter("SplineGradientBased/QPAccuracy").floatValue());
   if (path->length() == 0) return path;
   PathVectorPtr_t input = Base::cleanInput(path);
 
@@ -706,13 +706,14 @@ Problem::declareParameter(
                          "contains rows of zeros, in which case the "
                          "corresponding DoF is considered passive.",
                          Parameter(-1.)));
-Problem::declareParameter(
-    ParameterDescription(Parameter::BOOL, "SplineGradientBased/useProxqp",
-        "Use proxqp QP solver instead of eiquadprog_2011. Temporary parameter "
-        "that will be removed soon.", Parameter(true)));
-Problem::declareParameter(
-    ParameterDescription(Parameter::FLOAT, "SplineGradientBased/QPAccuracy",
-        "Accuracy of QP solver (only used by proxqp.", Parameter(1e-4)));
+Problem::declareParameter(ParameterDescription(
+    Parameter::BOOL, "SplineGradientBased/useProxqp",
+    "Use proxqp QP solver instead of eiquadprog_2011. Temporary parameter "
+    "that will be removed soon.",
+    Parameter(true)));
+Problem::declareParameter(ParameterDescription(
+    Parameter::FLOAT, "SplineGradientBased/QPAccuracy",
+    "Accuracy of QP solver (only used by proxqp.", Parameter(1e-4)));
 HPP_END_PARAMETER_DECLARATION(SplineGradientBased)
 }  // namespace pathOptimization
 }  // namespace core

--- a/src/path-optimization/spline-gradient-based.cc
+++ b/src/path-optimization/spline-gradient-based.cc
@@ -461,7 +461,7 @@ PathVectorPtr_t SplineGradientBased<_PB, _SO>::optimize(
     if (!this->validateBounds(splines, boundConstraint).empty())
       throw std::invalid_argument("Input path does not satisfy joint bounds");
   }
-  LinearConstraint boundConstraintReduced(constraint.PK.rows(), 0);
+  LinearConstraint boundConstraintReduced(0, 0);
   constraint.reduceConstraint(boundConstraint, boundConstraintReduced, false);
 
   // 6

--- a/src/path-optimization/spline-gradient-based.cc
+++ b/src/path-optimization/spline-gradient-based.cc
@@ -404,7 +404,8 @@ PathVectorPtr_t SplineGradientBased<_PB, _SO>::optimize(
       problem()->getParameter("SplineGradientBased/costThreshold").floatValue();
   bool useProxqp =
     problem()->getParameter("SplineGradientBased/useProxqp").boolValue();
-
+  value_type eps_abs(problem()->getParameter("SplineGradientBased/QPAccuracy").
+                     floatValue());
   if (path->length() == 0) return path;
   PathVectorPtr_t input = Base::cleanInput(path);
 
@@ -479,6 +480,7 @@ PathVectorPtr_t SplineGradientBased<_PB, _SO>::optimize(
   Reports_t reports;
 
   QuadraticProgram QP(cost.inputDerivativeSize_, useProxqp);
+  QP.accuracy(eps_abs);
   value_type optimalCost, costLowerBound = 0;
   cost.value(optimalCost, splines);
   hppDout(info, "Initial cost is " << optimalCost);
@@ -488,6 +490,8 @@ PathVectorPtr_t SplineGradientBased<_PB, _SO>::optimize(
 #endif  // NDEBUG
 
   QuadraticProgram QPc(QP, constraint, useProxqp);
+  QPc.accuracy(eps_abs);
+
   if (QPc.H.rows() == 0)
     // There are no variables left for optimization.
     return this->buildPathVector(splines);
@@ -706,6 +710,9 @@ Problem::declareParameter(
     ParameterDescription(Parameter::BOOL, "SplineGradientBased/useProxqp",
         "Use proxqp QP solver instead of eiquadprog_2011. Temporary parameter "
         "that will be removed soon.", Parameter(true)));
+Problem::declareParameter(
+    ParameterDescription(Parameter::FLOAT, "SplineGradientBased/QPAccuracy",
+        "Accuracy of QP solver (only used by proxqp.", Parameter(1e-4)));
 HPP_END_PARAMETER_DECLARATION(SplineGradientBased)
 }  // namespace pathOptimization
 }  // namespace core

--- a/tests/test-gradient-based.cc
+++ b/tests/test-gradient-based.cc
@@ -28,10 +28,10 @@
 // DAMAGE.
 
 #define BOOST_TEST_MODULE gradient_based
-
 #include <boost/test/included/unit_test.hpp>
 #include <cmath>
 #include <hpp/core/path-optimization/spline-gradient-based.hh>
+#include <hpp/core/continuous-validation/dichotomy.hh>
 #include <hpp/core/path-vector.hh>
 #include <hpp/core/problem.hh>
 #include <hpp/core/steering-method/straight.hh>
@@ -39,6 +39,11 @@
 #include <hpp/pinocchio/joint.hh>
 #include <hpp/pinocchio/urdf/util.hh>
 #include <pinocchio/fwd.hpp>
+#include <hpp/pinocchio/collision-object.hh>
+#include <pinocchio/algorithm/frames.hpp>
+#include <pinocchio/multibody/fcl.hpp>
+#include <pinocchio/multibody/geometry.hpp>
+#include <hpp/fcl/shape/geometric_shapes.h>
 
 using namespace hpp::core;
 using namespace hpp::pinocchio;
@@ -52,7 +57,7 @@ DevicePtr_t createRobot() {
       "<link name='body'>"
       "<collision>"
       "<geometry>"
-      "<box size='1 2 1'/>"
+      "<cylinder length='.2' radius='.1'/>"
       "</geometry>"
       "</collision>"
       "</link>"
@@ -73,14 +78,16 @@ DevicePtr_t createRobot() {
   return robot;
 }
 
-// Build a box robot moving in the plane
+// Build a cylindrical robot moving in the plane
 //
 // Create a circular path from (-1,0) to (1,0) with nominal orientation
 // with 3 waypoints of various orientations.
 // Optimal path should be a straight line: all waypoints aligned.
 // Check waypoints with expected value
 
-BOOST_AUTO_TEST_CASE(BFGS) {
+BOOST_AUTO_TEST_CASE(spline_optimization) {
+  Eigen::IOFormat eigenFmt(Eigen::FullPrecision);
+  ::hpp::debug::setVerbosityLevel(100);
   DevicePtr_t robot = createRobot();
   Configuration_t q0(robot->configSize());
   Configuration_t q1(robot->configSize());
@@ -121,42 +128,371 @@ BOOST_AUTO_TEST_CASE(BFGS) {
                         hpp::core::Parameter(1.));
   problem->setParameter("SplineGradientBased/costThreshold",
                         hpp::core::Parameter(1e-6));
-  PathOptimizerPtr_t pathOptimizer(
+  PathOptimizerPtr_t pathOptimizer1(
       pathOptimization::SplineGradientBased<path::BernsteinBasis, 1>::create(
           problem));
-  PathVectorPtr_t optimizedPath(pathOptimizer->optimize(path));
-  Configuration_t p0(robot->configSize());
-  Configuration_t p1(robot->configSize());
-  Configuration_t p2(robot->configSize());
-  Configuration_t p3(robot->configSize());
-  Configuration_t p4(robot->configSize());
-  BOOST_CHECK(optimizedPath->numberPaths() == 4);
-  p0 = optimizedPath->initial();
-  p1 = optimizedPath->pathAtRank(0)->end();
-  p2 = optimizedPath->pathAtRank(1)->end();
-  p3 = optimizedPath->pathAtRank(2)->end();
-  p4 = optimizedPath->pathAtRank(3)->end();
-  Configuration_t r0(robot->configSize());
+  PathOptimizerPtr_t pathOptimizer3(
+      pathOptimization::SplineGradientBased<path::BernsteinBasis, 3>::create(
+          problem));
+  PathOptimizerPtr_t pathOptimizer5(
+      pathOptimization::SplineGradientBased<path::BernsteinBasis, 5>::create(
+          problem));
+  PathVectorPtr_t optimizedPath1(pathOptimizer1->optimize(path));
+  PathVectorPtr_t optimizedPath3(pathOptimizer3->optimize(path));
+  PathVectorPtr_t optimizedPath5(pathOptimizer5->optimize(path));
+  BOOST_CHECK(optimizedPath1->numberPaths() == 4);
+  BOOST_CHECK(optimizedPath3->numberPaths() == 4);
+  BOOST_CHECK(optimizedPath5->numberPaths() == 4);
+  Configuration_t p00 = optimizedPath1->pathAtRank(0)->initial();
+  Configuration_t p01 = optimizedPath1->pathAtRank(0)->end();
+  Configuration_t p10 = optimizedPath1->pathAtRank(1)->initial();
+  Configuration_t p11 = optimizedPath1->pathAtRank(1)->end();
+  Configuration_t p20 = optimizedPath1->pathAtRank(2)->initial();
+  Configuration_t p21 = optimizedPath1->pathAtRank(2)->end();
+  Configuration_t p30 = optimizedPath1->pathAtRank(3)->initial();
+  Configuration_t p31 = optimizedPath1->pathAtRank(3)->end();
   Configuration_t r1(robot->configSize());
   Configuration_t r2(robot->configSize());
   Configuration_t r3(robot->configSize());
-  Configuration_t r4(robot->configSize());
-  r0 << -1, 0, 1, 0;
+  // Test spline of degree 1
   r1 << -0.5, 0, 1, 0;
   r2 << 0.0, 0, 1, 0;
   r3 << 0.5, 0, 1, 0;
-  r4 << 1, 0, 1, 0;
 
-  BOOST_CHECK((p0 - r0).norm() < 1e-10);
-  BOOST_CHECK((p1 - r1).norm() < 1e-10);
-  BOOST_CHECK((p2 - r2).norm() < 1e-10);
-  BOOST_CHECK((p3 - r3).norm() < 1e-10);
-  BOOST_CHECK((p4 - r4).norm() < 1e-10);
+  // Continuity
+  BOOST_CHECK((p00 - q0).norm() < 1e-10);
+  BOOST_CHECK((p01 - r1).norm() < 1e-10);
+  BOOST_CHECK((p10 - r1).norm() < 1e-10);
+  BOOST_CHECK((p11 - r2).norm() < 1e-10);
+  BOOST_CHECK((p20 - r2).norm() < 1e-10);
+  BOOST_CHECK((p21 - r3).norm() < 1e-10);
+  BOOST_CHECK((p30 - r3).norm() < 1e-10);
+  BOOST_CHECK((p31 - q4).norm() < 1e-10);
 
-  hppDout(info, (p0 - r0).norm());
-  hppDout(info, (p1 - r1).norm());
-  hppDout(info, (p2 - r2).norm());
-  hppDout(info, (p3 - r3).norm());
-  hppDout(info, (p4 - r4).norm());
+  // Test spline of degree 3
+  p00 = optimizedPath3->pathAtRank(0)->initial();
+  p01 = optimizedPath3->pathAtRank(0)->end();
+  p10 = optimizedPath3->pathAtRank(1)->initial();
+  p11 = optimizedPath3->pathAtRank(1)->end();
+  p20 = optimizedPath3->pathAtRank(2)->initial();
+  p21 = optimizedPath3->pathAtRank(2)->end();
+  p30 = optimizedPath3->pathAtRank(3)->initial();
+  p31 = optimizedPath3->pathAtRank(3)->end();
+  value_type L;
+  vector_t v00(robot->numberDof()), v01(robot->numberDof()),
+    v10(robot->numberDof()), v11(robot->numberDof()),
+    v20(robot->numberDof()), v21(robot->numberDof()),
+    v30(robot->numberDof()), v31(robot->numberDof());
+  L = optimizedPath3->pathAtRank(0)->length();
+  optimizedPath3->pathAtRank(0)->derivative(v00, 0, 1);
+  optimizedPath3->pathAtRank(0)->derivative(v01, L, 1);
+  L = optimizedPath3->pathAtRank(1)->length();
+  optimizedPath3->pathAtRank(1)->derivative(v10, 0, 1);
+  optimizedPath3->pathAtRank(1)->derivative(v11, L, 1);
+  L = optimizedPath3->pathAtRank(2)->length();
+  optimizedPath3->pathAtRank(2)->derivative(v20, 0, 1);
+  optimizedPath3->pathAtRank(2)->derivative(v21, L, 1);
+  L = optimizedPath3->pathAtRank(3)->length();
+  optimizedPath3->pathAtRank(3)->derivative(v30, 0, 1);
+  optimizedPath3->pathAtRank(3)->derivative(v31, L, 1);
+
+  r1 << -0.520833333333333, 0, 1, 0;
+  r2 << 0, 0, 1, 0;
+  r3 << 0.520833333333333, 0, 1, 0;
+
+  // Continuity
+  BOOST_CHECK((p00 - q0).norm() < 1e-10);
+  BOOST_CHECK((p01 - r1).norm() < 1e-10);
+  BOOST_CHECK((p10 - r1).norm() < 1e-10);
+  BOOST_CHECK((p11 - r2).norm() < 1e-10);
+  BOOST_CHECK((p20 - r2).norm() < 1e-10);
+  BOOST_CHECK((p21 - r3).norm() < 1e-10);
+  BOOST_CHECK((p30 - r3).norm() < 1e-10);
+  BOOST_CHECK((p31 - q4).norm() < 1e-10);
+
+  vector_t v0(robot->numberDof()), v1(robot->numberDof()),
+    v2(robot->numberDof()), v3(robot->numberDof()), v4(robot->numberDof());
+  v0 << 0, 0, 0;
+  v1 << 0.562800733001311, 0, 0;
+  v2 << 0.643200837715785, 0, 0;
+  v3 << 0.562800733001311, 0, 0;
+  v4 << 0, 0, 0;
+
+  // Continuity of the first derivative
+  BOOST_CHECK((v00 - v0).norm() < 1e-10);
+  BOOST_CHECK((v01 - v1).norm() < 1e-10);
+  BOOST_CHECK((v10 - v1).norm() < 1e-10);
+  BOOST_CHECK((v11 - v2).norm() < 1e-10);
+  BOOST_CHECK((v20 - v2).norm() < 1e-10);
+  BOOST_CHECK((v21 - v3).norm() < 1e-10);
+  BOOST_CHECK((v30 - v3).norm() < 1e-10);
+  BOOST_CHECK((v31 - v4).norm() < 1e-10);
+
+  // Test spline of degree 5
+  p00 = optimizedPath5->pathAtRank(0)->initial();
+  p01 = optimizedPath5->pathAtRank(0)->end();
+  p10 = optimizedPath5->pathAtRank(1)->initial();
+  p11 = optimizedPath5->pathAtRank(1)->end();
+  p20 = optimizedPath5->pathAtRank(2)->initial();
+  p21 = optimizedPath5->pathAtRank(2)->end();
+  p30 = optimizedPath5->pathAtRank(3)->initial();
+  p31 = optimizedPath5->pathAtRank(3)->end();
+
+  r1 << -0.553756964312603, 0, 1, 0;
+  r2 << 0, 0, 1, 0;
+  r3 << 0.553756964312603, 0, 1, 0;
+
+  // Continuity
+  BOOST_CHECK((p00 - q0).norm() < 1e-10);
+  BOOST_CHECK((p01 - r1).norm() < 1e-10);
+  BOOST_CHECK((p10 - r1).norm() < 1e-10);
+  BOOST_CHECK((p11 - r2).norm() < 1e-10);
+  BOOST_CHECK((p20 - r2).norm() < 1e-10);
+  BOOST_CHECK((p21 - r3).norm() < 1e-10);
+  BOOST_CHECK((p30 - r3).norm() < 1e-10);
+  BOOST_CHECK((p31 - q4).norm() < 1e-10);
+
+  L = optimizedPath5->pathAtRank(0)->length();
+  optimizedPath5->pathAtRank(0)->derivative(v00, 0, 1);
+  optimizedPath5->pathAtRank(0)->derivative(v01, L, 1);
+  L = optimizedPath5->pathAtRank(1)->length();
+  optimizedPath5->pathAtRank(1)->derivative(v10, 0, 1);
+  optimizedPath5->pathAtRank(1)->derivative(v11, L, 1);
+  L = optimizedPath5->pathAtRank(2)->length();
+  optimizedPath5->pathAtRank(2)->derivative(v20, 0, 1);
+  optimizedPath5->pathAtRank(2)->derivative(v21, L, 1);
+  L = optimizedPath5->pathAtRank(3)->length();
+  optimizedPath5->pathAtRank(3)->derivative(v30, 0, 1);
+  optimizedPath5->pathAtRank(3)->derivative(v31, L, 1);
+
+  v1 << 0.626154708000684, 0, 0;
+  v2 << 0.740925524548374, 0, 0;
+  v3 << 0.626154708000684, 0, 0;
+
+  // Continuity of the first derivative
+  BOOST_CHECK((v00 - v0).norm() < 1e-10);
+  BOOST_CHECK((v01 - v1).norm() < 1e-10);
+  BOOST_CHECK((v10 - v1).norm() < 1e-10);
+  BOOST_CHECK((v11 - v2).norm() < 1e-10);
+  BOOST_CHECK((v20 - v2).norm() < 1e-10);
+  BOOST_CHECK((v21 - v3).norm() < 1e-10);
+  BOOST_CHECK((v30 - v3).norm() < 1e-10);
+  BOOST_CHECK((v31 - v4).norm() < 1e-10);
+
+}
+
+//
+// Same as previously, but with a cylindrical obstacle
+//
+BOOST_AUTO_TEST_CASE(spline_optimization_obstacle) {
+  Eigen::IOFormat eigenFmt(Eigen::FullPrecision);
+  ::hpp::debug::setVerbosityLevel(100);
+  DevicePtr_t robot = createRobot();
+  Configuration_t q0(robot->configSize());
+  Configuration_t q1(robot->configSize());
+  Configuration_t q2(robot->configSize());
+  Configuration_t q3(robot->configSize());
+  Configuration_t q4(robot->configSize());
+  value_type s = sqrt(2) / 2;
+  value_type L, t, cost, dt=0.01;
+  q0(0) = -1;
+  q0(1) = 0;
+  q0(2) = 0;
+  q0(3) = 1;
+  q1(0) = -s;
+  q1(1) = s;
+  q1(2) = s;
+  q1(3) = s;
+  q2(0) = 0;
+  q2(1) = 1;
+  q2(2) = 1;
+  q2(3) = 0;
+  q3(0) = s;
+  q3(1) = s;
+  q3(2) = s;
+  q3(3) = -s;
+  q4(0) = 1;
+  q4(1) = 0;
+  q4(2) = 0;
+  q4(3) = -1;
+
+  ProblemPtr_t problem = Problem::create(robot);
+  PathValidationPtr_t pv(continuousValidation::Dichotomy::create(robot, 0));
+  problem->pathValidation(pv);
+  pinocchio::Model obstacleRModel;
+  hpp::pinocchio::GeomModelPtr_t obstacleModel(new hpp::pinocchio::GeomModel);
+  hpp::pinocchio::GeomDataPtr_t obstacleData(new hpp::pinocchio::GeomData
+                                             (*obstacleModel));
+  pinocchio::GeometryObject::CollisionGeometryPtr cylinder
+    (new hpp::fcl::Cylinder(0.2, 0.2));
+  matrix3_t I3(matrix3_t::Identity(3,3));
+  vector3_t T; T << -.2, 0, 0;
+  pinocchio::SE3 pose(I3, T);
+  ::pinocchio::GeomIndex id = obstacleModel->addGeometryObject
+      (::pinocchio::GeometryObject("obstacle", 0, cylinder, pose),
+       obstacleRModel);
+  obstacleData->oMg.resize(obstacleModel->ngeoms);
+  obstacleData->oMg[id] = obstacleModel->geometryObjects[id].placement;
+  CollisionObjectPtr_t object(new CollisionObject(obstacleModel, obstacleData,
+                                                  id));
+  problem->addObstacle(object);
+
+  SteeringMethodPtr_t sm = problem->steeringMethod();
+  PathVectorPtr_t path =
+      PathVector::create(robot->configSize(), robot->numberDof());
+  path->appendPath((*sm)(q0, q1));
+  path->appendPath((*sm)(q1, q2));
+  path->appendPath((*sm)(q2, q3));
+  path->appendPath((*sm)(q3, q4));
+
+  problem->setParameter("SplineGradientBased/alphaInit",
+                        hpp::core::Parameter(.5));
+  PathOptimizerPtr_t pathOptimizer1(
+      pathOptimization::SplineGradientBased<path::BernsteinBasis, 1>::create(
+          problem));
+  PathOptimizerPtr_t pathOptimizer3(
+      pathOptimization::SplineGradientBased<path::BernsteinBasis, 3>::create(
+          problem));
+  PathOptimizerPtr_t pathOptimizer5(
+      pathOptimization::SplineGradientBased<path::BernsteinBasis, 5>::create(
+          problem));
+  PathVectorPtr_t optimizedPath1(pathOptimizer1->optimize(path));
+  BOOST_CHECK(optimizedPath1->numberPaths() == 4);
+  Configuration_t p00 = optimizedPath1->pathAtRank(0)->initial();
+  Configuration_t p01 = optimizedPath1->pathAtRank(0)->end();
+  Configuration_t p10 = optimizedPath1->pathAtRank(1)->initial();
+  Configuration_t p11 = optimizedPath1->pathAtRank(1)->end();
+  Configuration_t p20 = optimizedPath1->pathAtRank(2)->initial();
+  Configuration_t p21 = optimizedPath1->pathAtRank(2)->end();
+  Configuration_t p30 = optimizedPath1->pathAtRank(3)->initial();
+  Configuration_t p31 = optimizedPath1->pathAtRank(3)->end();
+  Configuration_t r1(robot->configSize());
+  Configuration_t r2(robot->configSize());
+  Configuration_t r3(robot->configSize());
+  // Test spline of degree 1
+  // Continuity
+  BOOST_CHECK((p00 - q0).norm() < 1e-10);
+  BOOST_CHECK((p01 - p10).norm() < 1e-10);
+  BOOST_CHECK((p11 - p20).norm() < 1e-10);
+  BOOST_CHECK((p21 - p30).norm() < 1e-10);
+  BOOST_CHECK((p31 - q4).norm() < 1e-10);
+  L = optimizedPath1->length();
+  t = 0;
+  cost = 0;
+  while(t <= L) {
+    vector3_t v;
+    optimizedPath1->derivative(v, t, 1);
+    cost += dt * v.norm();
+    t += dt;
+  }
+  BOOST_CHECK(cost <= 4.);
+  // Test spline of degree 3
+  PathVectorPtr_t optimizedPath3(pathOptimizer3->optimize(path));
+  BOOST_CHECK(optimizedPath3->numberPaths() == 4);
+  p00 = optimizedPath3->pathAtRank(0)->initial();
+  p01 = optimizedPath3->pathAtRank(0)->end();
+  p10 = optimizedPath3->pathAtRank(1)->initial();
+  p11 = optimizedPath3->pathAtRank(1)->end();
+  p20 = optimizedPath3->pathAtRank(2)->initial();
+  p21 = optimizedPath3->pathAtRank(2)->end();
+  p30 = optimizedPath3->pathAtRank(3)->initial();
+  p31 = optimizedPath3->pathAtRank(3)->end();
+  vector_t v00(robot->numberDof()), v01(robot->numberDof()),
+    v10(robot->numberDof()), v11(robot->numberDof()),
+    v20(robot->numberDof()), v21(robot->numberDof()),
+    v30(robot->numberDof()), v31(robot->numberDof());
+  L = optimizedPath3->pathAtRank(0)->length();
+  optimizedPath3->pathAtRank(0)->derivative(v00, 0, 1);
+  optimizedPath3->pathAtRank(0)->derivative(v01, L, 1);
+  L = optimizedPath3->pathAtRank(1)->length();
+  optimizedPath3->pathAtRank(1)->derivative(v10, 0, 1);
+  optimizedPath3->pathAtRank(1)->derivative(v11, L, 1);
+  L = optimizedPath3->pathAtRank(2)->length();
+  optimizedPath3->pathAtRank(2)->derivative(v20, 0, 1);
+  optimizedPath3->pathAtRank(2)->derivative(v21, L, 1);
+  L = optimizedPath3->pathAtRank(3)->length();
+  optimizedPath3->pathAtRank(3)->derivative(v30, 0, 1);
+  optimizedPath3->pathAtRank(3)->derivative(v31, L, 1);
+
+  // Continuity
+  BOOST_CHECK((p00 - q0).norm() < 1e-10);
+  BOOST_CHECK((p01 - p10).norm() < 1e-10);
+  BOOST_CHECK((p11 - p20).norm() < 1e-10);
+  BOOST_CHECK((p21 - p30).norm() < 1e-10);
+  BOOST_CHECK((p31 - q4).norm() < 1e-10);
+
+  vector_t v0(robot->numberDof()), v1(robot->numberDof()),
+    v2(robot->numberDof()), v3(robot->numberDof()), v4(robot->numberDof());
+  v0 << 0, 0, 0;
+  v4 << 0, 0, 0;
+
+  // Continuity of the first derivative
+  BOOST_CHECK((v00 - v0).norm() < 1e-10);
+  BOOST_CHECK((v01 - v10).norm() < 1e-10);
+  BOOST_CHECK((v11 - v20).norm() < 1e-10);
+  BOOST_CHECK((v21 - v30).norm() < 1e-10);
+  BOOST_CHECK((v31 - v4).norm() < 1e-10);
+
+  L = optimizedPath3->length();
+  t = 0, dt=0.01;
+  cost = 0;
+  while(t <= L) {
+    vector3_t v;
+    optimizedPath3->derivative(v, t, 1);
+    cost += dt * v.norm();
+    t += dt;
+  }
+  BOOST_CHECK(cost <= 4.);
+
+  // Test spline of degree 5
+  PathVectorPtr_t optimizedPath5(pathOptimizer5->optimize(path));
+  BOOST_CHECK(optimizedPath5->numberPaths() == 4);
+  p00 = optimizedPath5->pathAtRank(0)->initial();
+  p01 = optimizedPath5->pathAtRank(0)->end();
+  p10 = optimizedPath5->pathAtRank(1)->initial();
+  p11 = optimizedPath5->pathAtRank(1)->end();
+  p20 = optimizedPath5->pathAtRank(2)->initial();
+  p21 = optimizedPath5->pathAtRank(2)->end();
+  p30 = optimizedPath5->pathAtRank(3)->initial();
+  p31 = optimizedPath5->pathAtRank(3)->end();
+
+  // Continuity
+  BOOST_CHECK((p00 - q0).norm() < 1e-10);
+  BOOST_CHECK((p01 - p10).norm() < 1e-10);
+  BOOST_CHECK((p11 - p20).norm() < 1e-10);
+  BOOST_CHECK((p21 - p30).norm() < 1e-10);
+  BOOST_CHECK((p31 - q4).norm() < 1e-10);
+
+  L = optimizedPath5->pathAtRank(0)->length();
+  optimizedPath5->pathAtRank(0)->derivative(v00, 0, 1);
+  optimizedPath5->pathAtRank(0)->derivative(v01, L, 1);
+  L = optimizedPath5->pathAtRank(1)->length();
+  optimizedPath5->pathAtRank(1)->derivative(v10, 0, 1);
+  optimizedPath5->pathAtRank(1)->derivative(v11, L, 1);
+  L = optimizedPath5->pathAtRank(2)->length();
+  optimizedPath5->pathAtRank(2)->derivative(v20, 0, 1);
+  optimizedPath5->pathAtRank(2)->derivative(v21, L, 1);
+  L = optimizedPath5->pathAtRank(3)->length();
+  optimizedPath5->pathAtRank(3)->derivative(v30, 0, 1);
+  optimizedPath5->pathAtRank(3)->derivative(v31, L, 1);
+
+  // Continuity of the first derivative
+  BOOST_CHECK((v00 - v0).norm() < 1e-10);
+  BOOST_CHECK((v01 - v10).norm() < 1e-10);
+  BOOST_CHECK((v11 - v20).norm() < 1e-10);
+  BOOST_CHECK((v21 - v30).norm() < 1e-10);
+  BOOST_CHECK((v31 - v4).norm() < 1e-10);
+
+  L = optimizedPath5->length();
+  t = 0, dt=0.01;
+  cost = 0;
+  while(t <= L) {
+    vector3_t v;
+    optimizedPath5->derivative(v, t, 1);
+    cost += dt * v.norm();
+    t += dt;
+  }
+  BOOST_CHECK(cost <= 4.);
+
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test-gradient-based.cc
+++ b/tests/test-gradient-based.cc
@@ -128,6 +128,8 @@ BOOST_AUTO_TEST_CASE(spline_optimization) {
                         hpp::core::Parameter(1.));
   problem->setParameter("SplineGradientBased/costThreshold",
                         hpp::core::Parameter(1e-6));
+  problem->setParameter("SplineGradientBased/QPAccuracy",
+                        hpp::core::Parameter(1e-10));
   PathOptimizerPtr_t pathOptimizer1(
       pathOptimization::SplineGradientBased<path::BernsteinBasis, 1>::create(
           problem));

--- a/tests/test-gradient-based.cc
+++ b/tests/test-gradient-based.cc
@@ -28,22 +28,23 @@
 // DAMAGE.
 
 #define BOOST_TEST_MODULE gradient_based
+#include <hpp/fcl/shape/geometric_shapes.h>
+
 #include <boost/test/included/unit_test.hpp>
 #include <cmath>
-#include <hpp/core/path-optimization/spline-gradient-based.hh>
 #include <hpp/core/continuous-validation/dichotomy.hh>
+#include <hpp/core/path-optimization/spline-gradient-based.hh>
 #include <hpp/core/path-vector.hh>
 #include <hpp/core/problem.hh>
 #include <hpp/core/steering-method/straight.hh>
+#include <hpp/pinocchio/collision-object.hh>
 #include <hpp/pinocchio/device.hh>
 #include <hpp/pinocchio/joint.hh>
 #include <hpp/pinocchio/urdf/util.hh>
-#include <pinocchio/fwd.hpp>
-#include <hpp/pinocchio/collision-object.hh>
 #include <pinocchio/algorithm/frames.hpp>
+#include <pinocchio/fwd.hpp>
 #include <pinocchio/multibody/fcl.hpp>
 #include <pinocchio/multibody/geometry.hpp>
-#include <hpp/fcl/shape/geometric_shapes.h>
 
 using namespace hpp::core;
 using namespace hpp::pinocchio;
@@ -182,9 +183,8 @@ BOOST_AUTO_TEST_CASE(spline_optimization) {
   p31 = optimizedPath3->pathAtRank(3)->end();
   value_type L;
   vector_t v00(robot->numberDof()), v01(robot->numberDof()),
-    v10(robot->numberDof()), v11(robot->numberDof()),
-    v20(robot->numberDof()), v21(robot->numberDof()),
-    v30(robot->numberDof()), v31(robot->numberDof());
+      v10(robot->numberDof()), v11(robot->numberDof()), v20(robot->numberDof()),
+      v21(robot->numberDof()), v30(robot->numberDof()), v31(robot->numberDof());
   L = optimizedPath3->pathAtRank(0)->length();
   optimizedPath3->pathAtRank(0)->derivative(v00, 0, 1);
   optimizedPath3->pathAtRank(0)->derivative(v01, L, 1);
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(spline_optimization) {
   BOOST_CHECK((p31 - q4).norm() < 1e-10);
 
   vector_t v0(robot->numberDof()), v1(robot->numberDof()),
-    v2(robot->numberDof()), v3(robot->numberDof()), v4(robot->numberDof());
+      v2(robot->numberDof()), v3(robot->numberDof()), v4(robot->numberDof());
   v0 << 0, 0, 0;
   v1 << 0.562800733001311, 0, 0;
   v2 << 0.643200837715785, 0, 0;
@@ -280,7 +280,6 @@ BOOST_AUTO_TEST_CASE(spline_optimization) {
   BOOST_CHECK((v21 - v3).norm() < 1e-10);
   BOOST_CHECK((v30 - v3).norm() < 1e-10);
   BOOST_CHECK((v31 - v4).norm() < 1e-10);
-
 }
 
 //
@@ -296,7 +295,7 @@ BOOST_AUTO_TEST_CASE(spline_optimization_obstacle) {
   Configuration_t q3(robot->configSize());
   Configuration_t q4(robot->configSize());
   value_type s = sqrt(2) / 2;
-  value_type L, t, cost, dt=0.01;
+  value_type L, t, cost, dt = 0.01;
   q0(0) = -1;
   q0(1) = 0;
   q0(2) = 0;
@@ -323,20 +322,21 @@ BOOST_AUTO_TEST_CASE(spline_optimization_obstacle) {
   problem->pathValidation(pv);
   pinocchio::Model obstacleRModel;
   hpp::pinocchio::GeomModelPtr_t obstacleModel(new hpp::pinocchio::GeomModel);
-  hpp::pinocchio::GeomDataPtr_t obstacleData(new hpp::pinocchio::GeomData
-                                             (*obstacleModel));
-  pinocchio::GeometryObject::CollisionGeometryPtr cylinder
-    (new hpp::fcl::Cylinder(0.2, 0.2));
-  matrix3_t I3(matrix3_t::Identity(3,3));
-  vector3_t T; T << -.2, 0, 0;
+  hpp::pinocchio::GeomDataPtr_t obstacleData(
+      new hpp::pinocchio::GeomData(*obstacleModel));
+  pinocchio::GeometryObject::CollisionGeometryPtr cylinder(
+      new hpp::fcl::Cylinder(0.2, 0.2));
+  matrix3_t I3(matrix3_t::Identity(3, 3));
+  vector3_t T;
+  T << -.2, 0, 0;
   pinocchio::SE3 pose(I3, T);
-  ::pinocchio::GeomIndex id = obstacleModel->addGeometryObject
-      (::pinocchio::GeometryObject("obstacle", 0, cylinder, pose),
-       obstacleRModel);
+  ::pinocchio::GeomIndex id = obstacleModel->addGeometryObject(
+      ::pinocchio::GeometryObject("obstacle", 0, cylinder, pose),
+      obstacleRModel);
   obstacleData->oMg.resize(obstacleModel->ngeoms);
   obstacleData->oMg[id] = obstacleModel->geometryObjects[id].placement;
-  CollisionObjectPtr_t object(new CollisionObject(obstacleModel, obstacleData,
-                                                  id));
+  CollisionObjectPtr_t object(
+      new CollisionObject(obstacleModel, obstacleData, id));
   problem->addObstacle(object);
 
   SteeringMethodPtr_t sm = problem->steeringMethod();
@@ -381,7 +381,7 @@ BOOST_AUTO_TEST_CASE(spline_optimization_obstacle) {
   L = optimizedPath1->length();
   t = 0;
   cost = 0;
-  while(t <= L) {
+  while (t <= L) {
     vector3_t v;
     optimizedPath1->derivative(v, t, 1);
     cost += dt * v.norm();
@@ -400,9 +400,8 @@ BOOST_AUTO_TEST_CASE(spline_optimization_obstacle) {
   p30 = optimizedPath3->pathAtRank(3)->initial();
   p31 = optimizedPath3->pathAtRank(3)->end();
   vector_t v00(robot->numberDof()), v01(robot->numberDof()),
-    v10(robot->numberDof()), v11(robot->numberDof()),
-    v20(robot->numberDof()), v21(robot->numberDof()),
-    v30(robot->numberDof()), v31(robot->numberDof());
+      v10(robot->numberDof()), v11(robot->numberDof()), v20(robot->numberDof()),
+      v21(robot->numberDof()), v30(robot->numberDof()), v31(robot->numberDof());
   L = optimizedPath3->pathAtRank(0)->length();
   optimizedPath3->pathAtRank(0)->derivative(v00, 0, 1);
   optimizedPath3->pathAtRank(0)->derivative(v01, L, 1);
@@ -424,7 +423,7 @@ BOOST_AUTO_TEST_CASE(spline_optimization_obstacle) {
   BOOST_CHECK((p31 - q4).norm() < 1e-10);
 
   vector_t v0(robot->numberDof()), v1(robot->numberDof()),
-    v2(robot->numberDof()), v3(robot->numberDof()), v4(robot->numberDof());
+      v2(robot->numberDof()), v3(robot->numberDof()), v4(robot->numberDof());
   v0 << 0, 0, 0;
   v4 << 0, 0, 0;
 
@@ -436,9 +435,9 @@ BOOST_AUTO_TEST_CASE(spline_optimization_obstacle) {
   BOOST_CHECK((v31 - v4).norm() < 1e-10);
 
   L = optimizedPath3->length();
-  t = 0, dt=0.01;
+  t = 0, dt = 0.01;
   cost = 0;
-  while(t <= L) {
+  while (t <= L) {
     vector3_t v;
     optimizedPath3->derivative(v, t, 1);
     cost += dt * v.norm();
@@ -486,15 +485,14 @@ BOOST_AUTO_TEST_CASE(spline_optimization_obstacle) {
   BOOST_CHECK((v31 - v4).norm() < 1e-10);
 
   L = optimizedPath5->length();
-  t = 0, dt=0.01;
+  t = 0, dt = 0.01;
   cost = 0;
-  while(t <= L) {
+  while (t <= L) {
     vector3_t v;
     optimizedPath5->derivative(v, t, 1);
     cost += dt * v.norm();
     t += dt;
   }
   BOOST_CHECK(cost <= 4.);
-
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This pull request
  - adds a dependency to proxsuite and uses proxqp with sparse representation in QuadraticProgram class.
  - allow to switch back to eiquadprog in case of problems using a Problem parameter (this feature is temporary).
  - extends unit test `test-gradient-based`.

The new version has been tested on `pr2-in-iai-kitchen` (config size = 38) with very good results:
   - with Bezier splines of degree 1, average time (for 20 runs) for planning and optimizing : 27s instead of 36.16,
More interesting, using sparsity for the same problem, but with Bezier splines of degree 3, we plan and optimize in 47s instead of 2283s (only 1 run both with proxqp).