### PR TITLE
[pathOptimization] Add Reeds and Shepp time parameterization.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ set(${PROJECT_NAME}_HEADERS
     include/hpp/core/path-optimization/partial-shortcut.hh
     include/hpp/core/path-optimization/quadratic-program.hh
     include/hpp/core/path-optimization/random-shortcut.hh
+    include/hpp/core/path-optimization/rs-time-parameterization.hh
     include/hpp/core/path-optimization/simple-shortcut.hh
     include/hpp/core/path-optimization/simple-time-parameterization.hh
     include/hpp/core/path-optimization/spline-gradient-based.hh
@@ -229,6 +230,9 @@ set(${PROJECT_NAME}_SOURCES
     src/path-optimization/spline-gradient-based-abstract.cc #
     src/path-optimization/partial-shortcut.cc #
     src/path-optimization/random-shortcut.cc
+    src/path-optimization/reeds-shepp/piecewise-quadratic.cc
+    src/path-optimization/reeds-shepp/piecewise-quadratic.hh
+    src/path-optimization/rs-time-parameterization.cc
     src/path-optimization/simple-shortcut.cc
     src/path-optimization/simple-time-parameterization.cc #
     src/path-planner.cc #

--- a/include/hpp/core/fwd.hh
+++ b/include/hpp/core/fwd.hh
@@ -291,6 +291,8 @@ HPP_PREDEF_CLASS(PathLength);
 typedef shared_ptr<PathLength> PathLengthPtr_t;
 HPP_PREDEF_CLASS(PartialShortcut);
 typedef shared_ptr<PartialShortcut> PartialShortcutPtr_t;
+HPP_PREDEF_CLASS(RSTimeParameterization);
+typedef shared_ptr<RSTimeParameterization> RSTimeParameterizationPtr_t;
 HPP_PREDEF_CLASS(SimpleTimeParameterization);
 typedef shared_ptr<SimpleTimeParameterization> SimpleTimeParameterizationPtr_t;
 HPP_PREDEF_CLASS(ConfigOptimization);

--- a/include/hpp/core/path-optimization/rs-time-parameterization.hh
+++ b/include/hpp/core/path-optimization/rs-time-parameterization.hh
@@ -1,0 +1,73 @@
+//
+// Copyright (c) 2019 - 2024 CNRS
+//
+// Author: Florent Lamiraux
+//
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+
+#ifndef HPP_CORE_PATH_OPTIMIZATION_RS_TIME_PARAMETERIZATION_HH
+#define  HPP_CORE_PATH_OPTIMIZATION_RS_TIME_PARAMETERIZATION_HH
+
+#include <hpp/core/path-optimizer.hh>
+#include <hpp/core/steering-method/constant-curvature.hh>
+
+namespace hpp {
+namespace core {
+namespace pathOptimization {
+  /// Time parameterization of Reeds and Shepp paths
+  ///
+  /// This class computes a time parameterization for a concatentation
+  /// of Reeds and Shepp paths (in fact of constant curvature paths)
+  class HPP_CORE_DLLAPI RSTimeParameterization : public PathOptimizer
+  {
+  public:
+    /// Create instance and return shared pointer
+    static RSTimeParameterizationPtr_t create(const ProblemConstPtr_t& problem);
+    /// Compute the time parameterization of a path
+    ///
+    /// \param path input path,
+    /// \precond path should be a concatenation of
+    ///          hpp::core::ConstantCurvature instances
+    ///
+    /// The parameterized path starts and ends with velocity equal to 0.
+    /// On each segment, it accelerates, moves at maximal speed and
+    /// decelerates to the minimal velocity to pass curvature discontinuity.
+    virtual PathVectorPtr_t optimize(const PathVectorPtr_t& path);
+  protected:
+    /// Constructor
+    /// \param minLinVel, maxLinVel minimal and maximal velocity.
+    ///        Minimal velocity is the linear velocity allowed when
+    ///        switching discontinuously the radius of curvature,
+    /// \param maxAngVel maximal angular velocity,
+    /// \param linearAcceletion linearDeceleration linear acceleration and
+    ///        deceleration that can be different.
+    RSTimeParameterization(const ProblemConstPtr_t& problem) : PathOptimizer(problem) {}
+  }; // class ReedsShepp
+
+} // namespace pathOptimization
+} // namespace core
+} // namespace hpp
+#endif // HPP_CORE_PATH_OPTIMIZATION_RS_TIME_PARAMETERIZATION_HH

--- a/include/hpp/core/path-optimization/rs-time-parameterization.hh
+++ b/include/hpp/core/path-optimization/rs-time-parameterization.hh
@@ -29,7 +29,7 @@
 // DAMAGE.
 
 #ifndef HPP_CORE_PATH_OPTIMIZATION_RS_TIME_PARAMETERIZATION_HH
-#define  HPP_CORE_PATH_OPTIMIZATION_RS_TIME_PARAMETERIZATION_HH
+#define HPP_CORE_PATH_OPTIMIZATION_RS_TIME_PARAMETERIZATION_HH
 
 #include <hpp/core/path-optimizer.hh>
 #include <hpp/core/steering-method/constant-curvature.hh>
@@ -37,37 +37,38 @@
 namespace hpp {
 namespace core {
 namespace pathOptimization {
-  /// Time parameterization of Reeds and Shepp paths
+/// Time parameterization of Reeds and Shepp paths
+///
+/// This class computes a time parameterization for a concatentation
+/// of Reeds and Shepp paths (in fact of constant curvature paths)
+class HPP_CORE_DLLAPI RSTimeParameterization : public PathOptimizer {
+ public:
+  /// Create instance and return shared pointer
+  static RSTimeParameterizationPtr_t create(const ProblemConstPtr_t& problem);
+  /// Compute the time parameterization of a path
   ///
-  /// This class computes a time parameterization for a concatentation
-  /// of Reeds and Shepp paths (in fact of constant curvature paths)
-  class HPP_CORE_DLLAPI RSTimeParameterization : public PathOptimizer
-  {
-  public:
-    /// Create instance and return shared pointer
-    static RSTimeParameterizationPtr_t create(const ProblemConstPtr_t& problem);
-    /// Compute the time parameterization of a path
-    ///
-    /// \param path input path,
-    /// \precond path should be a concatenation of
-    ///          hpp::core::ConstantCurvature instances
-    ///
-    /// The parameterized path starts and ends with velocity equal to 0.
-    /// On each segment, it accelerates, moves at maximal speed and
-    /// decelerates to the minimal velocity to pass curvature discontinuity.
-    virtual PathVectorPtr_t optimize(const PathVectorPtr_t& path);
-  protected:
-    /// Constructor
-    /// \param minLinVel, maxLinVel minimal and maximal velocity.
-    ///        Minimal velocity is the linear velocity allowed when
-    ///        switching discontinuously the radius of curvature,
-    /// \param maxAngVel maximal angular velocity,
-    /// \param linearAcceletion linearDeceleration linear acceleration and
-    ///        deceleration that can be different.
-    RSTimeParameterization(const ProblemConstPtr_t& problem) : PathOptimizer(problem) {}
-  }; // class ReedsShepp
+  /// \param path input path,
+  /// \precond path should be a concatenation of
+  ///          hpp::core::ConstantCurvature instances
+  ///
+  /// The parameterized path starts and ends with velocity equal to 0.
+  /// On each segment, it accelerates, moves at maximal speed and
+  /// decelerates to the minimal velocity to pass curvature discontinuity.
+  virtual PathVectorPtr_t optimize(const PathVectorPtr_t& path);
 
-} // namespace pathOptimization
-} // namespace core
-} // namespace hpp
-#endif // HPP_CORE_PATH_OPTIMIZATION_RS_TIME_PARAMETERIZATION_HH
+ protected:
+  /// Constructor
+  /// \param minLinVel, maxLinVel minimal and maximal velocity.
+  ///        Minimal velocity is the linear velocity allowed when
+  ///        switching discontinuously the radius of curvature,
+  /// \param maxAngVel maximal angular velocity,
+  /// \param linearAcceletion linearDeceleration linear acceleration and
+  ///        deceleration that can be different.
+  RSTimeParameterization(const ProblemConstPtr_t& problem)
+      : PathOptimizer(problem) {}
+};  // class ReedsShepp
+
+}  // namespace pathOptimization
+}  // namespace core
+}  // namespace hpp
+#endif  // HPP_CORE_PATH_OPTIMIZATION_RS_TIME_PARAMETERIZATION_HH

--- a/src/path-optimization/reeds-shepp/piecewise-quadratic.cc
+++ b/src/path-optimization/reeds-shepp/piecewise-quadratic.cc
@@ -1,0 +1,181 @@
+//
+// Copyright (c) 2019 CNRS
+//
+// Author: Florent Lamiraux
+//
+
+#include "path-optimization/reeds-shepp/piecewise-quadratic.hh"
+
+namespace hpp {
+namespace core {
+namespace pathOptimization {
+namespace reedsShepp {
+
+  using hpp::core::interval_t;
+
+  PiecewiseQuadraticPtr_t PiecewiseQuadratic::create
+  (const value_type& initVel)
+  {
+    PiecewiseQuadratic* ptr (new PiecewiseQuadratic (initVel));
+    PiecewiseQuadraticPtr_t shPtr (ptr);
+    ptr->init (shPtr);
+    return shPtr;
+  }
+
+  PiecewiseQuadraticPtr_t PiecewiseQuadratic::createCopy
+  (const PiecewiseQuadraticPtr_t& other)
+  {
+    PiecewiseQuadratic* ptr (new PiecewiseQuadratic (*other));
+    PiecewiseQuadraticPtr_t shPtr (ptr);
+    ptr->init (shPtr);
+    return shPtr;
+  }
+
+  hpp::core::TimeParameterizationPtr_t PiecewiseQuadratic::copy () const
+  {
+    return createCopy (weak_.lock ());
+  }
+
+  void PiecewiseQuadratic::init (const PiecewiseQuadraticWkPtr_t& weak)
+  {
+    weak_ = weak;
+  }
+
+  interval_t PiecewiseQuadratic::definitionInterval () const
+  {
+    return interval_t (0, times_.back ());
+  }
+
+  size_type PiecewiseQuadratic::findInterval (value_type t) const
+  {
+    assert (t > -sqrt (std::numeric_limits <value_type>::epsilon ()));
+    assert (times_.size () >= 2);
+    if (t < 0) t = 0;
+    for (std::size_t i=1; i < times_.size (); ++i) {
+      if (t <= times_ [i]) return i-1;
+    }
+    return times_.size () - 1;
+  }
+
+  value_type PiecewiseQuadratic::value (const value_type &t) const
+  {
+    size_type index = findInterval (t);
+    std::size_t i ((std::size_t) index);
+    value_type ti = times_ [i];
+    return a_ [i] * (t-ti) * (t-ti) + b_ [i] * (t-ti) + c_ [i];
+  }
+  value_type PiecewiseQuadratic::derivative
+  (const value_type &t, const size_type &order) const
+  {
+    size_type index = findInterval (t);
+    if (index < 0) return 0;
+    if ((std::size_t)index >= times_.size ()) return 0;
+    std::size_t i ((std::size_t) index);
+    value_type ti = times_ [i];
+    if (order == 1) {
+      return 2 * a_ [i] * (t-ti) + b_ [i];
+    } else if (order == 2) {
+      return 2 * a_ [i];
+    } else {
+      return 0;
+    }
+  }
+  value_type PiecewiseQuadratic::derivativeBound
+  (const value_type &low, const value_type &up) const
+  {
+    return std::max (fabs (derivative (low, 1)), fabs (derivative (up, 1)));
+  }
+
+  void PiecewiseQuadratic::addSegments
+  (const value_type& distance, const value_type& accel,
+   const value_type& decel, const value_type& maxVel,
+   const value_type& targetVel)
+  {
+    value_type endValue = 0, endVel = initVel_, a, b, c;
+    // endVel is the velocity at the end of the previous segment,
+    // therefore at the beginning of this one.
+    assert (maxVel >= targetVel);
+    assert (maxVel >= initVel_);
+    assert (accel > 0);
+    assert (decel > 0);
+    assert (distance > 0);
+    if (distance < 1e-8) return;
+    // time for reaching maximal velocity
+    value_type tacc = (maxVel - initVel_) / accel;
+    // time for reaching end velocity
+    value_type tdec = (maxVel - targetVel) / decel;
+    // distance travelled during tacc and tdec
+    value_type dacc = .5 * tacc * (initVel_ + maxVel);
+    value_type ddec = .5 * tdec * (targetVel + maxVel);
+    // Test whether there is a constant speed segment
+    if (dacc + ddec < distance) {
+      // There is a constant speed segment between accel and decel
+      value_type remainingDist = distance - dacc + ddec;
+      value_type tint = remainingDist / maxVel;
+      // Add 3 segment
+      // Acceleration
+      a = .5 * accel;    a_.push_back (a);
+      b = initVel_;      b_.push_back (b);
+      c = endValue;      c_.push_back (c);
+      times_.push_back (times_.back () + tacc);
+      endValue = a * tacc * tacc + b * tacc + c;
+      endVel = 2 * a * tacc + b;
+      // Constant speed
+      a = 0;        a_.push_back (a);
+      b = endVel;   b_.push_back (b);
+      c = endValue; c_.push_back (c);
+      times_.push_back (times_.back () + tint);
+      endValue = a * tint *tint + b * tint + c;
+      endVel = 2 * a * tint + b;
+      // Deceleration
+      a = -.5 * decel;   a_.push_back (a);
+      b = endVel;        b_.push_back (b);
+      c = endValue;      c_.push_back (c);
+      times_.push_back (times_.back () + tdec);
+      endValue = a * tdec *tdec + b * tdec + c;
+      endVel = 2 * a * tdec + b;
+    } else if (distance < .5*(endVel*endVel - targetVel*targetVel)
+	       /decel) {
+      // Distance too small to stop
+      value_type decel2 = .5*(endVel*endVel - targetVel*targetVel)
+	/ distance;
+      tdec = (endVel - targetVel)/decel2;
+      // Deceleration
+      a = -.5 * decel2; a_.push_back (a);
+      b = endVel;       b_.push_back (b);
+      c = endValue;     c_.push_back (c);
+      endValue = a * tdec * tdec + b * tdec + c;
+      endVel = 2 * a * tdec + b;
+      times_.push_back (times_.back () + tdec);
+    } else {
+      // There is no constant speed segment between accel and decel
+      value_type vmax = sqrt ((decel*accel)/(decel + accel)*
+			      (2*distance + endVel * endVel / accel +
+			       targetVel * targetVel / decel));
+      tacc = (vmax - endVel) / accel;
+      tdec = (vmax - targetVel)/decel;
+      assert (fabs (distance -
+		    .5 * (tacc*(endVel+vmax) + tdec*(vmax+targetVel))) <
+	      1e-8);
+      // add 2 segments
+      // Acceleration
+      a = .5 * accel; a_.push_back (a);
+      b = endVel;     b_.push_back (b);
+      c = endValue;   c_.push_back (c);
+      endValue = a * tacc * tacc + b * tacc + c;
+      endVel = 2 * a * tacc + b;
+      times_.push_back (times_.back () + tacc);
+      // Deceleration
+      a = -.5 * decel; a_.push_back (a);
+      b = endVel;      b_.push_back (b);
+      c = endValue;    c_.push_back (c);
+      endValue = a * tdec * tdec + b * tdec + c;
+      endVel = 2 * a * tdec + b;
+      times_.push_back (times_.back () + tdec);
+    }
+  }
+
+} // namespace reedsShepp
+} // namespace pathOptimization
+} // namespace core
+} // namespace hpp

--- a/src/path-optimization/reeds-shepp/piecewise-quadratic.cc
+++ b/src/path-optimization/reeds-shepp/piecewise-quadratic.cc
@@ -11,171 +11,178 @@ namespace core {
 namespace pathOptimization {
 namespace reedsShepp {
 
-  using hpp::core::interval_t;
+using hpp::core::interval_t;
 
-  PiecewiseQuadraticPtr_t PiecewiseQuadratic::create
-  (const value_type& initVel)
-  {
-    PiecewiseQuadratic* ptr (new PiecewiseQuadratic (initVel));
-    PiecewiseQuadraticPtr_t shPtr (ptr);
-    ptr->init (shPtr);
-    return shPtr;
-  }
+PiecewiseQuadraticPtr_t PiecewiseQuadratic::create(const value_type& initVel) {
+  PiecewiseQuadratic* ptr(new PiecewiseQuadratic(initVel));
+  PiecewiseQuadraticPtr_t shPtr(ptr);
+  ptr->init(shPtr);
+  return shPtr;
+}
 
-  PiecewiseQuadraticPtr_t PiecewiseQuadratic::createCopy
-  (const PiecewiseQuadraticPtr_t& other)
-  {
-    PiecewiseQuadratic* ptr (new PiecewiseQuadratic (*other));
-    PiecewiseQuadraticPtr_t shPtr (ptr);
-    ptr->init (shPtr);
-    return shPtr;
-  }
+PiecewiseQuadraticPtr_t PiecewiseQuadratic::createCopy(
+    const PiecewiseQuadraticPtr_t& other) {
+  PiecewiseQuadratic* ptr(new PiecewiseQuadratic(*other));
+  PiecewiseQuadraticPtr_t shPtr(ptr);
+  ptr->init(shPtr);
+  return shPtr;
+}
 
-  hpp::core::TimeParameterizationPtr_t PiecewiseQuadratic::copy () const
-  {
-    return createCopy (weak_.lock ());
-  }
+hpp::core::TimeParameterizationPtr_t PiecewiseQuadratic::copy() const {
+  return createCopy(weak_.lock());
+}
 
-  void PiecewiseQuadratic::init (const PiecewiseQuadraticWkPtr_t& weak)
-  {
-    weak_ = weak;
-  }
+void PiecewiseQuadratic::init(const PiecewiseQuadraticWkPtr_t& weak) {
+  weak_ = weak;
+}
 
-  interval_t PiecewiseQuadratic::definitionInterval () const
-  {
-    return interval_t (0, times_.back ());
-  }
+interval_t PiecewiseQuadratic::definitionInterval() const {
+  return interval_t(0, times_.back());
+}
 
-  size_type PiecewiseQuadratic::findInterval (value_type t) const
-  {
-    assert (t > -sqrt (std::numeric_limits <value_type>::epsilon ()));
-    assert (times_.size () >= 2);
-    if (t < 0) t = 0;
-    for (std::size_t i=1; i < times_.size (); ++i) {
-      if (t <= times_ [i]) return i-1;
-    }
-    return times_.size () - 1;
+size_type PiecewiseQuadratic::findInterval(value_type t) const {
+  assert(t > -sqrt(std::numeric_limits<value_type>::epsilon()));
+  assert(times_.size() >= 2);
+  if (t < 0) t = 0;
+  for (std::size_t i = 1; i < times_.size(); ++i) {
+    if (t <= times_[i]) return i - 1;
   }
+  return times_.size() - 1;
+}
 
-  value_type PiecewiseQuadratic::value (const value_type &t) const
-  {
-    size_type index = findInterval (t);
-    std::size_t i ((std::size_t) index);
-    value_type ti = times_ [i];
-    return a_ [i] * (t-ti) * (t-ti) + b_ [i] * (t-ti) + c_ [i];
+value_type PiecewiseQuadratic::value(const value_type& t) const {
+  size_type index = findInterval(t);
+  std::size_t i((std::size_t)index);
+  value_type ti = times_[i];
+  return a_[i] * (t - ti) * (t - ti) + b_[i] * (t - ti) + c_[i];
+}
+value_type PiecewiseQuadratic::derivative(const value_type& t,
+                                          const size_type& order) const {
+  size_type index = findInterval(t);
+  if (index < 0) return 0;
+  if ((std::size_t)index >= times_.size()) return 0;
+  std::size_t i((std::size_t)index);
+  value_type ti = times_[i];
+  if (order == 1) {
+    return 2 * a_[i] * (t - ti) + b_[i];
+  } else if (order == 2) {
+    return 2 * a_[i];
+  } else {
+    return 0;
   }
-  value_type PiecewiseQuadratic::derivative
-  (const value_type &t, const size_type &order) const
-  {
-    size_type index = findInterval (t);
-    if (index < 0) return 0;
-    if ((std::size_t)index >= times_.size ()) return 0;
-    std::size_t i ((std::size_t) index);
-    value_type ti = times_ [i];
-    if (order == 1) {
-      return 2 * a_ [i] * (t-ti) + b_ [i];
-    } else if (order == 2) {
-      return 2 * a_ [i];
-    } else {
-      return 0;
-    }
-  }
-  value_type PiecewiseQuadratic::derivativeBound
-  (const value_type &low, const value_type &up) const
-  {
-    return std::max (fabs (derivative (low, 1)), fabs (derivative (up, 1)));
-  }
+}
+value_type PiecewiseQuadratic::derivativeBound(const value_type& low,
+                                               const value_type& up) const {
+  return std::max(fabs(derivative(low, 1)), fabs(derivative(up, 1)));
+}
 
-  void PiecewiseQuadratic::addSegments
-  (const value_type& distance, const value_type& accel,
-   const value_type& decel, const value_type& maxVel,
-   const value_type& targetVel)
-  {
-    value_type endValue = 0, endVel = initVel_, a, b, c;
-    // endVel is the velocity at the end of the previous segment,
-    // therefore at the beginning of this one.
-    assert (maxVel >= targetVel);
-    assert (maxVel >= initVel_);
-    assert (accel > 0);
-    assert (decel > 0);
-    assert (distance > 0);
-    if (distance < 1e-8) return;
-    // time for reaching maximal velocity
-    value_type tacc = (maxVel - initVel_) / accel;
-    // time for reaching end velocity
-    value_type tdec = (maxVel - targetVel) / decel;
-    // distance travelled during tacc and tdec
-    value_type dacc = .5 * tacc * (initVel_ + maxVel);
-    value_type ddec = .5 * tdec * (targetVel + maxVel);
-    // Test whether there is a constant speed segment
-    if (dacc + ddec < distance) {
-      // There is a constant speed segment between accel and decel
-      value_type remainingDist = distance - dacc + ddec;
-      value_type tint = remainingDist / maxVel;
-      // Add 3 segment
-      // Acceleration
-      a = .5 * accel;    a_.push_back (a);
-      b = initVel_;      b_.push_back (b);
-      c = endValue;      c_.push_back (c);
-      times_.push_back (times_.back () + tacc);
-      endValue = a * tacc * tacc + b * tacc + c;
-      endVel = 2 * a * tacc + b;
-      // Constant speed
-      a = 0;        a_.push_back (a);
-      b = endVel;   b_.push_back (b);
-      c = endValue; c_.push_back (c);
-      times_.push_back (times_.back () + tint);
-      endValue = a * tint *tint + b * tint + c;
-      endVel = 2 * a * tint + b;
-      // Deceleration
-      a = -.5 * decel;   a_.push_back (a);
-      b = endVel;        b_.push_back (b);
-      c = endValue;      c_.push_back (c);
-      times_.push_back (times_.back () + tdec);
-      endValue = a * tdec *tdec + b * tdec + c;
-      endVel = 2 * a * tdec + b;
-    } else if (distance < .5*(endVel*endVel - targetVel*targetVel)
-	       /decel) {
-      // Distance too small to stop
-      value_type decel2 = .5*(endVel*endVel - targetVel*targetVel)
-	/ distance;
-      tdec = (endVel - targetVel)/decel2;
-      // Deceleration
-      a = -.5 * decel2; a_.push_back (a);
-      b = endVel;       b_.push_back (b);
-      c = endValue;     c_.push_back (c);
-      endValue = a * tdec * tdec + b * tdec + c;
-      endVel = 2 * a * tdec + b;
-      times_.push_back (times_.back () + tdec);
-    } else {
-      // There is no constant speed segment between accel and decel
-      value_type vmax = sqrt ((decel*accel)/(decel + accel)*
-			      (2*distance + endVel * endVel / accel +
-			       targetVel * targetVel / decel));
-      tacc = (vmax - endVel) / accel;
-      tdec = (vmax - targetVel)/decel;
-      assert (fabs (distance -
-		    .5 * (tacc*(endVel+vmax) + tdec*(vmax+targetVel))) <
-	      1e-8);
-      // add 2 segments
-      // Acceleration
-      a = .5 * accel; a_.push_back (a);
-      b = endVel;     b_.push_back (b);
-      c = endValue;   c_.push_back (c);
-      endValue = a * tacc * tacc + b * tacc + c;
-      endVel = 2 * a * tacc + b;
-      times_.push_back (times_.back () + tacc);
-      // Deceleration
-      a = -.5 * decel; a_.push_back (a);
-      b = endVel;      b_.push_back (b);
-      c = endValue;    c_.push_back (c);
-      endValue = a * tdec * tdec + b * tdec + c;
-      endVel = 2 * a * tdec + b;
-      times_.push_back (times_.back () + tdec);
-    }
+void PiecewiseQuadratic::addSegments(const value_type& distance,
+                                     const value_type& accel,
+                                     const value_type& decel,
+                                     const value_type& maxVel,
+                                     const value_type& targetVel) {
+  value_type endValue = 0, endVel = initVel_, a, b, c;
+  // endVel is the velocity at the end of the previous segment,
+  // therefore at the beginning of this one.
+  assert(maxVel >= targetVel);
+  assert(maxVel >= initVel_);
+  assert(accel > 0);
+  assert(decel > 0);
+  assert(distance > 0);
+  if (distance < 1e-8) return;
+  // time for reaching maximal velocity
+  value_type tacc = (maxVel - initVel_) / accel;
+  // time for reaching end velocity
+  value_type tdec = (maxVel - targetVel) / decel;
+  // distance travelled during tacc and tdec
+  value_type dacc = .5 * tacc * (initVel_ + maxVel);
+  value_type ddec = .5 * tdec * (targetVel + maxVel);
+  // Test whether there is a constant speed segment
+  if (dacc + ddec < distance) {
+    // There is a constant speed segment between accel and decel
+    value_type remainingDist = distance - dacc + ddec;
+    value_type tint = remainingDist / maxVel;
+    // Add 3 segment
+    // Acceleration
+    a = .5 * accel;
+    a_.push_back(a);
+    b = initVel_;
+    b_.push_back(b);
+    c = endValue;
+    c_.push_back(c);
+    times_.push_back(times_.back() + tacc);
+    endValue = a * tacc * tacc + b * tacc + c;
+    endVel = 2 * a * tacc + b;
+    // Constant speed
+    a = 0;
+    a_.push_back(a);
+    b = endVel;
+    b_.push_back(b);
+    c = endValue;
+    c_.push_back(c);
+    times_.push_back(times_.back() + tint);
+    endValue = a * tint * tint + b * tint + c;
+    endVel = 2 * a * tint + b;
+    // Deceleration
+    a = -.5 * decel;
+    a_.push_back(a);
+    b = endVel;
+    b_.push_back(b);
+    c = endValue;
+    c_.push_back(c);
+    times_.push_back(times_.back() + tdec);
+    endValue = a * tdec * tdec + b * tdec + c;
+    endVel = 2 * a * tdec + b;
+  } else if (distance <
+             .5 * (endVel * endVel - targetVel * targetVel) / decel) {
+    // Distance too small to stop
+    value_type decel2 =
+        .5 * (endVel * endVel - targetVel * targetVel) / distance;
+    tdec = (endVel - targetVel) / decel2;
+    // Deceleration
+    a = -.5 * decel2;
+    a_.push_back(a);
+    b = endVel;
+    b_.push_back(b);
+    c = endValue;
+    c_.push_back(c);
+    endValue = a * tdec * tdec + b * tdec + c;
+    endVel = 2 * a * tdec + b;
+    times_.push_back(times_.back() + tdec);
+  } else {
+    // There is no constant speed segment between accel and decel
+    value_type vmax = sqrt((decel * accel) / (decel + accel) *
+                           (2 * distance + endVel * endVel / accel +
+                            targetVel * targetVel / decel));
+    tacc = (vmax - endVel) / accel;
+    tdec = (vmax - targetVel) / decel;
+    assert(fabs(distance - .5 * (tacc * (endVel + vmax) +
+                                 tdec * (vmax + targetVel))) < 1e-8);
+    // add 2 segments
+    // Acceleration
+    a = .5 * accel;
+    a_.push_back(a);
+    b = endVel;
+    b_.push_back(b);
+    c = endValue;
+    c_.push_back(c);
+    endValue = a * tacc * tacc + b * tacc + c;
+    endVel = 2 * a * tacc + b;
+    times_.push_back(times_.back() + tacc);
+    // Deceleration
+    a = -.5 * decel;
+    a_.push_back(a);
+    b = endVel;
+    b_.push_back(b);
+    c = endValue;
+    c_.push_back(c);
+    endValue = a * tdec * tdec + b * tdec + c;
+    endVel = 2 * a * tdec + b;
+    times_.push_back(times_.back() + tdec);
   }
+}
 
-} // namespace reedsShepp
-} // namespace pathOptimization
-} // namespace core
-} // namespace hpp
+}  // namespace reedsShepp
+}  // namespace pathOptimization
+}  // namespace core
+}  // namespace hpp

--- a/src/path-optimization/reeds-shepp/piecewise-quadratic.hh
+++ b/src/path-optimization/reeds-shepp/piecewise-quadratic.hh
@@ -38,63 +38,64 @@ namespace core {
 namespace pathOptimization {
 namespace reedsShepp {
 
-  using hpp::core::interval_t;
-  HPP_PREDEF_CLASS (PiecewiseQuadratic);
-  typedef hpp::shared_ptr <PiecewiseQuadratic> PiecewiseQuadraticPtr_t;
+using hpp::core::interval_t;
+HPP_PREDEF_CLASS(PiecewiseQuadratic);
+typedef hpp::shared_ptr<PiecewiseQuadratic> PiecewiseQuadraticPtr_t;
 
-  /// Piecewise quadratic time parameterization
+/// Piecewise quadratic time parameterization
+///
+/// On each interval \f$[t_i,t_{i+1}], f (t) = a_i (t-t_i) + b_i(t-t_i) +
+/// c_i^2\f$.
+class PiecewiseQuadratic : public hpp::core::TimeParameterization {
+ public:
+  /// Create an instance
+  /// \param initVel initial velocity
+  static PiecewiseQuadraticPtr_t create(const value_type& initVel);
+  static PiecewiseQuadraticPtr_t createCopy(
+      const PiecewiseQuadraticPtr_t& other);
+  virtual hpp::core::TimeParameterizationPtr_t copy() const;
+  interval_t definitionInterval() const;
+  virtual value_type value(const value_type& t) const;
+  virtual value_type derivative(const value_type& t,
+                                const size_type& order) const;
+  virtual value_type derivativeBound(const value_type& low,
+                                     const value_type& up) const;
+  /// Add up to 3 constant acceleration segments
   ///
-  /// On each interval \f$[t_i,t_{i+1}], f (t) = a_i (t-t_i) + b_i(t-t_i) + c_i^2\f$.
-  class PiecewiseQuadratic : public hpp::core::TimeParameterization
-  {
-  public:
-    /// Create an instance
-    /// \param initVel initial velocity
-    static PiecewiseQuadraticPtr_t create (const value_type& initVel);
-    static PiecewiseQuadraticPtr_t createCopy
-    (const PiecewiseQuadraticPtr_t& other);
-    virtual hpp::core::TimeParameterizationPtr_t copy () const;
-    interval_t definitionInterval () const;
-    virtual value_type value (const value_type &t) const;
-    virtual value_type derivative
-    (const value_type &t, const size_type &order) const;
-    virtual value_type derivativeBound
-    (const value_type &low, const value_type &up) const;
-    /// Add up to 3 constant acceleration segments
-    ///
-    /// \param distance distance travelled on these segments,
-    /// \param accel constant acceleration on the first segment,
-    /// \param decel constant negative acceleration on the last segment,
-    /// \param maxVel constant velocity on the middle segment
-    /// \param targetVel velocity at the end of the segment
-    /// \note depending on the distance, one of the above segment might be
-    ///       of size 0, and therefore not represented.
-    void addSegments (const value_type& distance, const value_type& accel,
-		      const value_type& decel, const value_type& maxVel,
-		      const value_type& targetVel);
-  protected:
-    PiecewiseQuadratic (const value_type& initVel) :
-      initVel_ (initVel)
-    {
-      times_.push_back (0);
-    }
+  /// \param distance distance travelled on these segments,
+  /// \param accel constant acceleration on the first segment,
+  /// \param decel constant negative acceleration on the last segment,
+  /// \param maxVel constant velocity on the middle segment
+  /// \param targetVel velocity at the end of the segment
+  /// \note depending on the distance, one of the above segment might be
+  ///       of size 0, and therefore not represented.
+  void addSegments(const value_type& distance, const value_type& accel,
+                   const value_type& decel, const value_type& maxVel,
+                   const value_type& targetVel);
 
-    PiecewiseQuadratic (const PiecewiseQuadratic& other) :
-      hpp::core::TimeParameterization (other), times_ (other.times_),
-      a_ (other.a_), b_ (other.b_), c_ (other.c_),
-      initVel_ (other.initVel_)
-    {
-    }
-    void init (const PiecewiseQuadraticWkPtr_t& weak);
-  private:
-    size_type findInterval (value_type t) const;
-    std::vector <value_type> times_;
-    std::vector <value_type> a_, b_, c_;
-    value_type initVel_;
-    PiecewiseQuadraticWkPtr_t weak_;
-  }; // class PiecewiseQuadratic
-} // namespace reedsShepp
-} // namespace pathOptimization
-} // namespace core
-} // namespace hpp
-#endif // HPP_CORE_PATH_OPTIMIZATION_REEDS_SHEPP_PIECEWISE_QUADRATIC_HH
+ protected:
+  PiecewiseQuadratic(const value_type& initVel) : initVel_(initVel) {
+    times_.push_back(0);
+  }
+
+  PiecewiseQuadratic(const PiecewiseQuadratic& other)
+      : hpp::core::TimeParameterization(other),
+        times_(other.times_),
+        a_(other.a_),
+        b_(other.b_),
+        c_(other.c_),
+        initVel_(other.initVel_) {}
+  void init(const PiecewiseQuadraticWkPtr_t& weak);
+
+ private:
+  size_type findInterval(value_type t) const;
+  std::vector<value_type> times_;
+  std::vector<value_type> a_, b_, c_;
+  value_type initVel_;
+  PiecewiseQuadraticWkPtr_t weak_;
+};  // class PiecewiseQuadratic
+}  // namespace reedsShepp
+}  // namespace pathOptimization
+}  // namespace core
+}  // namespace hpp
+#endif  // HPP_CORE_PATH_OPTIMIZATION_REEDS_SHEPP_PIECEWISE_QUADRATIC_HH

--- a/src/path-optimization/reeds-shepp/piecewise-quadratic.hh
+++ b/src/path-optimization/reeds-shepp/piecewise-quadratic.hh
@@ -1,0 +1,100 @@
+//
+// Copyright (c) 2019 - 2024 CNRS
+//
+// Author: Florent Lamiraux
+//
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+
+#ifndef HPP_CORE_PATH_OPTIMIZATION_REEDS_SHEPP_PIECEWISE_QUADRATIC_HH
+#define HPP_CORE_PATH_OPTIMIZATION_REEDS_SHEPP_PIECEWISE_QUADRATIC_HH
+
+#include <hpp/core/time-parameterization.hh>
+
+namespace hpp {
+namespace core {
+namespace pathOptimization {
+namespace reedsShepp {
+
+  using hpp::core::interval_t;
+  HPP_PREDEF_CLASS (PiecewiseQuadratic);
+  typedef hpp::shared_ptr <PiecewiseQuadratic> PiecewiseQuadraticPtr_t;
+
+  /// Piecewise quadratic time parameterization
+  ///
+  /// On each interval \f$[t_i,t_{i+1}], f (t) = a_i (t-t_i) + b_i(t-t_i) + c_i^2\f$.
+  class PiecewiseQuadratic : public hpp::core::TimeParameterization
+  {
+  public:
+    /// Create an instance
+    /// \param initVel initial velocity
+    static PiecewiseQuadraticPtr_t create (const value_type& initVel);
+    static PiecewiseQuadraticPtr_t createCopy
+    (const PiecewiseQuadraticPtr_t& other);
+    virtual hpp::core::TimeParameterizationPtr_t copy () const;
+    interval_t definitionInterval () const;
+    virtual value_type value (const value_type &t) const;
+    virtual value_type derivative
+    (const value_type &t, const size_type &order) const;
+    virtual value_type derivativeBound
+    (const value_type &low, const value_type &up) const;
+    /// Add up to 3 constant acceleration segments
+    ///
+    /// \param distance distance travelled on these segments,
+    /// \param accel constant acceleration on the first segment,
+    /// \param decel constant negative acceleration on the last segment,
+    /// \param maxVel constant velocity on the middle segment
+    /// \param targetVel velocity at the end of the segment
+    /// \note depending on the distance, one of the above segment might be
+    ///       of size 0, and therefore not represented.
+    void addSegments (const value_type& distance, const value_type& accel,
+		      const value_type& decel, const value_type& maxVel,
+		      const value_type& targetVel);
+  protected:
+    PiecewiseQuadratic (const value_type& initVel) :
+      initVel_ (initVel)
+    {
+      times_.push_back (0);
+    }
+
+    PiecewiseQuadratic (const PiecewiseQuadratic& other) :
+      hpp::core::TimeParameterization (other), times_ (other.times_),
+      a_ (other.a_), b_ (other.b_), c_ (other.c_),
+      initVel_ (other.initVel_)
+    {
+    }
+    void init (const PiecewiseQuadraticWkPtr_t& weak);
+  private:
+    size_type findInterval (value_type t) const;
+    std::vector <value_type> times_;
+    std::vector <value_type> a_, b_, c_;
+    value_type initVel_;
+    PiecewiseQuadraticWkPtr_t weak_;
+  }; // class PiecewiseQuadratic
+} // namespace reedsShepp
+} // namespace pathOptimization
+} // namespace core
+} // namespace hpp
+#endif // HPP_CORE_PATH_OPTIMIZATION_REEDS_SHEPP_PIECEWISE_QUADRATIC_HH

--- a/src/path-optimization/rs-time-parameterization.cc
+++ b/src/path-optimization/rs-time-parameterization.cc
@@ -1,0 +1,151 @@
+//
+// Copyright (c) 2019 - 2024 CNRS
+//
+// Author: Florent Lamiraux
+//
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+
+#include <hpp/core/path-optimization/rs-time-parameterization.hh>
+#include <hpp/core/path-vector.hh>
+#include <hpp/core/problem.hh>
+#include <path-optimization/reeds-shepp/piecewise-quadratic.hh>
+
+namespace hpp {
+namespace core {
+namespace pathOptimization {
+
+  RSTimeParameterizationPtr_t RSTimeParameterization::create(const ProblemConstPtr_t& problem)
+  {
+    RSTimeParameterization* pointer(new RSTimeParameterization(problem));
+    return RSTimeParameterizationPtr_t(pointer);
+  }
+
+  PathVectorPtr_t RSTimeParameterization::optimize(const PathVectorPtr_t& path)
+  {
+    using reedsShepp::PiecewiseQuadratic;
+    using reedsShepp::PiecewiseQuadraticPtr_t;
+    value_type minLinVel_(problem()->getParameter("RSTimeParameterization/MinLinearVelocity").
+			  floatValue());
+    value_type maxLinVel_(problem()->getParameter("RSTimeParameterization/MaxLinearVelocity").
+			  floatValue());
+    value_type maxAngVel_(problem()->getParameter("RSTimeParameterization/MaxAngularVelocity").
+			  floatValue());
+    value_type linearAcceleration_(
+        problem()->getParameter("RSTimeParameterization/LinearAcceleration").floatValue());
+    value_type linearDeceleration_(
+        problem()->getParameter("RSTimeParameterization/LinearDeceleration").floatValue());
+
+    // Retrieve parameters from problem
+    
+    value_type eps (sqrt (std::numeric_limits <value_type>::epsilon ()));
+    PathVectorPtr_t flattenedPath (PathVector::create
+				   (path->outputSize (),
+				    path->outputDerivativeSize ()));
+    // Flatten input path in case it contains PathVector instances with
+    // ConstantCurvature instances.
+    path->flatten (flattenedPath);
+    PathVectorPtr_t result (PathVector::create
+			    (path->outputSize (),
+			     path->outputDerivativeSize ()));
+
+    // Start with zero velocity and end first segment with the
+    // minimal velocity
+    value_type initVel(0), targetVel(minLinVel_), maxLinVel;
+    value_type linearAcceleration, linearDeceleration;
+    // Loop over each constant curvature segment
+    for (std::size_t i=0; i<flattenedPath->numberPaths (); ++i) {
+      // if last segment, end with 0 velocity
+      targetVel = 0;
+      PathPtr_t p (flattenedPath->pathAtRank (i)->copy ());
+      if (p->length () > eps) {
+	value_type t0 (p->timeRange ().second);
+	vector_t v0 (p->outputDerivativeSize ());
+	p->derivative (v0, t0, 1);
+	if (i != flattenedPath->numberPaths () - 1) {
+	  // If two consecutive segments are in the same direction (i.e.
+	  // forward or backward), decelerate to minLinVel_
+	  PathPtr_t next (flattenedPath->pathAtRank (i+1));
+	  value_type t1 (next->timeRange ().first);
+	  vector_t v1 (next->outputDerivativeSize ());
+	  next->derivative (v1, t1, 1);
+	  if ((v1-v0).head <2> ().norm () < 1e-3) {
+	    targetVel = minLinVel_;
+	  }
+	}
+	// Compute maximal linear velocity
+	value_type curvature (fabs (v0 [2]));
+	hppDout (info, "curvature=" << curvature);
+	if (curvature * maxLinVel_ < maxAngVel_) {
+	  // Sature linear velocity
+	  maxLinVel = maxLinVel_;
+	  linearAcceleration = linearAcceleration_;
+	  linearDeceleration = linearDeceleration_;
+	} else {
+	  // Saturate angular velocity
+	  maxLinVel = maxAngVel_/curvature;
+	  // reduce accelerations by the same ratio
+	  // We could also add maximal angular acceleration parameter
+	  linearAcceleration =
+	    linearAcceleration_ * maxLinVel/maxLinVel_;
+	  linearDeceleration =
+	    linearDeceleration_ * maxLinVel/maxLinVel_;
+	}
+	// Create one parameterization per segment
+	PiecewiseQuadraticPtr_t param
+	  (PiecewiseQuadratic::create (initVel));
+	param->addSegments (p->length (), linearAcceleration,
+			    linearDeceleration, maxLinVel,
+			    targetVel);
+	p->timeParameterization (param, param->definitionInterval ());
+	result->appendPath (p);
+	// From second segment, start at minimal velocity
+	initVel = minLinVel_;
+      }
+    }
+    return result;
+  }
+  // ----------- Declare parameters ------------------------------------- //
+
+HPP_START_PARAMETER_DECLARATION(RSTimeParameterization)
+Problem::declareParameter(ParameterDescription(
+    Parameter::FLOAT, "RSTimeParameterization/MinLinearVelocity",
+    "Maximal linear velocity allowed when crossing a curvature discontinuity", Parameter(.1)));
+Problem::declareParameter(ParameterDescription(
+    Parameter::FLOAT, "RSTimeParameterization/MaxLinearVelocity",
+    "Maximal linear velocity", Parameter(1.)));
+Problem::declareParameter(ParameterDescription(
+    Parameter::FLOAT, "RSTimeParameterization/MaxAngularVelocity",
+    "Maximal angular velocity", Parameter(1.)));
+Problem::declareParameter(ParameterDescription(
+    Parameter::FLOAT, "RSTimeParameterization/LinearAcceleration",
+    "Linear acceleration", Parameter(1.)));
+Problem::declareParameter(ParameterDescription(
+    Parameter::FLOAT, "RSTimeParameterization/LinearDeceleration",
+    "Linear deceleration", Parameter(1.)));
+HPP_END_PARAMETER_DECLARATION(RSTimeParameterization)
+} // namespace pathOptimization
+} // namespace core
+} // namespace hpp

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -49,6 +49,7 @@
 #include <hpp/core/kinodynamic-distance.hh>
 #include <hpp/core/path-optimization/partial-shortcut.hh>
 #include <hpp/core/path-optimization/random-shortcut.hh>
+#include <hpp/core/path-optimization/rs-time-parameterization.hh>
 #include <hpp/core/path-optimization/simple-shortcut.hh>
 #include <hpp/core/path-optimization/simple-time-parameterization.hh>
 #include <hpp/core/path-planner/bi-rrt-star.hh>
@@ -245,6 +246,8 @@ ProblemSolver::ProblemSolver()
                      pathOptimization::PartialShortcut::create);
   pathOptimizers.add("SimpleTimeParameterization",
                      pathOptimization::SimpleTimeParameterization::create);
+  pathOptimizers.add("RSTimeParameterization",
+                     pathOptimization::RSTimeParameterization::create);
 
   // Store path validation methods in map.
   pathValidations.add("NoValidation", pathValidation::NoValidation::create);


### PR DESCRIPTION
  This code is imported from bas-coverage project, but was developed after
  the end of the project. Thus it belongs to CNRS.