### PR TITLE
Add SearchInRoadmap path planner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ set(${PROJECT_NAME}_HEADERS
     include/hpp/core/path-planning-failed.hh
     include/hpp/core/path-planner/k-prm-star.hh
     include/hpp/core/path-planner/bi-rrt-star.hh
+    include/hpp/core/path-planner/search-in-roadmap.hh
     include/hpp/core/path-validation.hh
     include/hpp/core/path-validation-report.hh
     include/hpp/core/path-vector.hh

--- a/include/hpp/core/path-planner/bi-rrt-star.hh
+++ b/include/hpp/core/path-planner/bi-rrt-star.hh
@@ -38,6 +38,9 @@ namespace pathPlanner {
 HPP_PREDEF_CLASS(BiRrtStar);
 typedef shared_ptr<BiRrtStar> BiRrtStarPtr_t;
 
+/// \addtogroup path_planning
+/// \{
+
 /// Bi-RRT* path planning algorithm
 /// as described in http://www.golems.org/papers/AkgunIROS11-sampling.pdf
 class HPP_CORE_DLLAPI BiRrtStar : public PathPlanner {
@@ -111,6 +114,9 @@ class HPP_CORE_DLLAPI BiRrtStar : public PathPlanner {
   /// Weak pointer to itself
   BiRrtStarWkPtr_t weak_;
 };  // class BiRrtStar
+
+/// \}
+
 }  // namespace pathPlanner
 }  // namespace core
 }  // namespace hpp

--- a/include/hpp/core/path-planner/k-prm-star.hh
+++ b/include/hpp/core/path-planner/k-prm-star.hh
@@ -35,6 +35,10 @@
 namespace hpp {
 namespace core {
 namespace pathPlanner {
+
+/// \addtogroup path_planning
+/// \{
+
 /// k-PRM* path planning algorithm
 /// as described in https://arxiv.org/pdf/1105.1186.pdf.
 class HPP_CORE_DLLAPI kPrmStar : public PathPlanner {
@@ -107,6 +111,9 @@ class HPP_CORE_DLLAPI kPrmStar : public PathPlanner {
   /// Weak pointer to itself
   kPrmStarWkPtr_t weak_;
 };  // class kPrmStar
+
+/// \}
+
 }  // namespace pathPlanner
 }  // namespace core
 }  // namespace hpp

--- a/include/hpp/core/path-planner/search-in-roadmap.hh
+++ b/include/hpp/core/path-planner/search-in-roadmap.hh
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2024 CNRS
+// Authors: Florent Lamiraux
+//
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+
+#ifndef HPP_CORE_PATH_PLANNER_SEARCH_IN_ROADMAP_HH
+#define HPP_CORE_PATH_PLANNER_SEARCH_IN_ROADMAP_HH
+
+#include <hpp/core/path-planner.hh>
+#include <hpp/core/path-planning-failed.hh>
+
+namespace hpp{
+namespace core {
+namespace pathPlanner{
+  HPP_PREDEF_CLASS(SearchInRoadmap);
+  typedef shared_ptr<SearchInRoadmap> SearchInRoadmapPtr_t;
+  /// \addtogroup path_planning
+  /// \{
+
+  /// Search in the roadmap without modifying it and without trying a direct connection priorly
+  ///
+  /// This planner is especially useful in some applications where the roadmap is constructed
+  /// externally like in coverage planning. This planner will return a path if one exists in the
+  /// roadmap or throw otherwise.
+  ///
+  /// \note One shortcoming of this planner (as all other planners), if the initial configuration
+  /// is the same as a goal configuration, the planner will return a path of length 0. This is not
+  /// desirable in coverage planning applications.
+  class SearchInRoadmap : public PathPlanner {
+  public:
+    static SearchInRoadmapPtr_t createWithRoadmap(const ProblemConstPtr_t& problem,
+						  const RoadmapPtr_t& roadmap)
+    {
+      return SearchInRoadmapPtr_t(new SearchInRoadmap(problem, roadmap));
+    }
+    /// This methods does nothing
+    virtual void tryConnectInitAndGoals()
+    {
+    }
+    /// This methods does nothing
+    virtual void oneStep()
+    {
+      throw path_planning_failed("SearchInRoadmap: no goal configuration in the connected component"
+				 "of initial configuration.");
+    }
+  protected:
+    SearchInRoadmap(const ProblemConstPtr_t& problem) : core::PathPlanner(problem)
+    {
+    }
+    SearchInRoadmap(const ProblemConstPtr_t& problem, const RoadmapPtr_t& roadmap) :
+      PathPlanner(problem, roadmap)
+    {
+    }
+  }; /// class SearchInRoadmap
+
+/// \}
+  
+}
+}
+}
+    
+#endif // HPP_CORE_PATH_PLANNER_SEARCH_IN_ROADMAP_HH
+

--- a/include/hpp/core/path-planner/search-in-roadmap.hh
+++ b/include/hpp/core/path-planner/search-in-roadmap.hh
@@ -33,55 +33,51 @@
 #include <hpp/core/path-planner.hh>
 #include <hpp/core/path-planning-failed.hh>
 
-namespace hpp{
+namespace hpp {
 namespace core {
-namespace pathPlanner{
-  HPP_PREDEF_CLASS(SearchInRoadmap);
-  typedef shared_ptr<SearchInRoadmap> SearchInRoadmapPtr_t;
-  /// \addtogroup path_planning
-  /// \{
+namespace pathPlanner {
+HPP_PREDEF_CLASS(SearchInRoadmap);
+typedef shared_ptr<SearchInRoadmap> SearchInRoadmapPtr_t;
+/// \addtogroup path_planning
+/// \{
 
-  /// Search in the roadmap without modifying it and without trying a direct connection priorly
-  ///
-  /// This planner is especially useful in some applications where the roadmap is constructed
-  /// externally like in coverage planning. This planner will return a path if one exists in the
-  /// roadmap or throw otherwise.
-  ///
-  /// \note One shortcoming of this planner (as all other planners), if the initial configuration
-  /// is the same as a goal configuration, the planner will return a path of length 0. This is not
-  /// desirable in coverage planning applications.
-  class SearchInRoadmap : public PathPlanner {
-  public:
-    static SearchInRoadmapPtr_t createWithRoadmap(const ProblemConstPtr_t& problem,
-						  const RoadmapPtr_t& roadmap)
-    {
-      return SearchInRoadmapPtr_t(new SearchInRoadmap(problem, roadmap));
-    }
-    /// This methods does nothing
-    virtual void tryConnectInitAndGoals()
-    {
-    }
-    /// This methods does nothing
-    virtual void oneStep()
-    {
-      throw path_planning_failed("SearchInRoadmap: no goal configuration in the connected component"
-				 "of initial configuration.");
-    }
-  protected:
-    SearchInRoadmap(const ProblemConstPtr_t& problem) : core::PathPlanner(problem)
-    {
-    }
-    SearchInRoadmap(const ProblemConstPtr_t& problem, const RoadmapPtr_t& roadmap) :
-      PathPlanner(problem, roadmap)
-    {
-    }
-  }; /// class SearchInRoadmap
+/// Search in the roadmap without modifying it and without trying a direct
+/// connection priorly
+///
+/// This planner is especially useful in some applications where the roadmap is
+/// constructed externally like in coverage planning. This planner will return a
+/// path if one exists in the roadmap or throw otherwise.
+///
+/// \note One shortcoming of this planner (as all other planners), if the
+/// initial configuration is the same as a goal configuration, the planner will
+/// return a path of length 0. This is not desirable in coverage planning
+/// applications.
+class SearchInRoadmap : public PathPlanner {
+ public:
+  static SearchInRoadmapPtr_t createWithRoadmap(
+      const ProblemConstPtr_t& problem, const RoadmapPtr_t& roadmap) {
+    return SearchInRoadmapPtr_t(new SearchInRoadmap(problem, roadmap));
+  }
+  /// This methods does nothing
+  virtual void tryConnectInitAndGoals() {}
+  /// This methods does nothing
+  virtual void oneStep() {
+    throw path_planning_failed(
+        "SearchInRoadmap: no goal configuration in the connected component"
+        "of initial configuration.");
+  }
+
+ protected:
+  SearchInRoadmap(const ProblemConstPtr_t& problem)
+      : core::PathPlanner(problem) {}
+  SearchInRoadmap(const ProblemConstPtr_t& problem, const RoadmapPtr_t& roadmap)
+      : PathPlanner(problem, roadmap) {}
+};  /// class SearchInRoadmap
 
 /// \}
-  
-}
-}
-}
-    
-#endif // HPP_CORE_PATH_PLANNER_SEARCH_IN_ROADMAP_HH
 
+}  // namespace pathPlanner
+}  // namespace core
+}  // namespace hpp
+
+#endif  // HPP_CORE_PATH_PLANNER_SEARCH_IN_ROADMAP_HH

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -54,6 +54,7 @@
 #include <hpp/core/path-optimization/simple-time-parameterization.hh>
 #include <hpp/core/path-planner/bi-rrt-star.hh>
 #include <hpp/core/path-planner/k-prm-star.hh>
+#include <hpp/core/path-planner/search-in-roadmap.hh>
 #include <hpp/core/path-projector/dichotomy.hh>
 #include <hpp/core/path-projector/global.hh>
 #include <hpp/core/path-projector/progressive.hh>
@@ -210,6 +211,7 @@ ProblemSolver::ProblemSolver()
   pathPlanners.add("BiRRTPlanner", BiRRTPlanner::createWithRoadmap);
   pathPlanners.add("kPRM*", pathPlanner::kPrmStar::createWithRoadmap);
   pathPlanners.add("BiRRT*", pathPlanner::BiRrtStar::createWithRoadmap);
+  pathPlanners.add("SearchInRoadmap", hpp::core::pathPlanner::SearchInRoadmap::createWithRoadmap);
 
   configurationShooters.add("Uniform", createUniformConfigShooter);
   configurationShooters.add("Gaussian", createGaussianConfigShooter);

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -211,7 +211,8 @@ ProblemSolver::ProblemSolver()
   pathPlanners.add("BiRRTPlanner", BiRRTPlanner::createWithRoadmap);
   pathPlanners.add("kPRM*", pathPlanner::kPrmStar::createWithRoadmap);
   pathPlanners.add("BiRRT*", pathPlanner::BiRrtStar::createWithRoadmap);
-  pathPlanners.add("SearchInRoadmap", hpp::core::pathPlanner::SearchInRoadmap::createWithRoadmap);
+  pathPlanners.add("SearchInRoadmap",
+                   hpp::core::pathPlanner::SearchInRoadmap::createWithRoadmap);
 
   configurationShooters.add("Uniform", createUniformConfigShooter);
   configurationShooters.add("Gaussian", createGaussianConfigShooter);

--- a/tests/roadmap-1.cc
+++ b/tests/roadmap-1.cc
@@ -32,12 +32,12 @@
 #include <hpp/core/nearest-neighbor.hh>
 #include <hpp/core/node.hh>
 #include <hpp/core/parser/roadmap.hh>
+#include <hpp/core/path-planner/search-in-roadmap.hh>
 #include <hpp/core/path-vector.hh>
 #include <hpp/core/problem.hh>
 #include <hpp/core/roadmap.hh>
 #include <hpp/core/steering-method/straight.hh>
 #include <hpp/core/weighed-distance.hh>
-#include <hpp/core/path-planner/search-in-roadmap.hh>
 #include <hpp/pinocchio/configuration.hh>
 #include <hpp/pinocchio/device.hh>
 #include <hpp/pinocchio/joint.hh>
@@ -289,26 +289,34 @@ BOOST_AUTO_TEST_CASE(Roadmap1) {
 
   r->resetGoalNodes();
   // Check pathPlanner::SearchInRoadmap
-  q[0] = 0; q[1] = 0;
+  q[0] = 0;
+  q[1] = 0;
   p->initConfig(q);
-  q[0] = 2.5; q[1] = 2.9;
+  q[0] = 2.5;
+  q[1] = 2.9;
   p->addGoalConfig(q);
-  pathPlanner::SearchInRoadmapPtr_t planner(pathPlanner::SearchInRoadmap::createWithRoadmap(p, r));
+  pathPlanner::SearchInRoadmapPtr_t planner(
+      pathPlanner::SearchInRoadmap::createWithRoadmap(p, r));
   PathVectorPtr_t pv(planner->solve());
   BOOST_CHECK(pv);
   BOOST_CHECK(pv->numberPaths() == 4);
-  q[0] = 0; q[1] = 0;
+  q[0] = 0;
+  q[1] = 0;
   BOOST_CHECK(pv->pathAtRank(0)->initial() == q);
-  q[0] = 1; q[1] = 0;
+  q[0] = 1;
+  q[1] = 0;
   BOOST_CHECK(pv->pathAtRank(0)->end() == q);
   BOOST_CHECK(pv->pathAtRank(1)->initial() == q);
-  q[0] = .5; q[1] = .9;
+  q[0] = .5;
+  q[1] = .9;
   BOOST_CHECK(pv->pathAtRank(1)->end() == q);
   BOOST_CHECK(pv->pathAtRank(2)->initial() == q);
-  q[0] = 1.5; q[1] = 2.9;
+  q[0] = 1.5;
+  q[1] = 2.9;
   BOOST_CHECK(pv->pathAtRank(2)->end() == q);
   BOOST_CHECK(pv->pathAtRank(3)->initial() == q);
-  q[0] = 2.5; q[1] = 2.9;
+  q[0] = 2.5;
+  q[1] = 2.9;
   BOOST_CHECK(pv->pathAtRank(3)->end() == q);
 
   // Check that memory if well deallocated.

--- a/tests/roadmap-1.cc
+++ b/tests/roadmap-1.cc
@@ -32,10 +32,12 @@
 #include <hpp/core/nearest-neighbor.hh>
 #include <hpp/core/node.hh>
 #include <hpp/core/parser/roadmap.hh>
+#include <hpp/core/path-vector.hh>
 #include <hpp/core/problem.hh>
 #include <hpp/core/roadmap.hh>
 #include <hpp/core/steering-method/straight.hh>
 #include <hpp/core/weighed-distance.hh>
+#include <hpp/core/path-planner/search-in-roadmap.hh>
 #include <hpp/pinocchio/configuration.hh>
 #include <hpp/pinocchio/device.hh>
 #include <hpp/pinocchio/joint.hh>
@@ -284,6 +286,30 @@ BOOST_AUTO_TEST_CASE(Roadmap1) {
   BOOST_CHECK(nodes[0]->connectedComponent() == nodes[5]->connectedComponent());
   BOOST_CHECK(r->pathExists());
   BOOST_TEST_MESSAGE(*r);
+
+  r->resetGoalNodes();
+  // Check pathPlanner::SearchInRoadmap
+  q[0] = 0; q[1] = 0;
+  p->initConfig(q);
+  q[0] = 2.5; q[1] = 2.9;
+  p->addGoalConfig(q);
+  pathPlanner::SearchInRoadmapPtr_t planner(pathPlanner::SearchInRoadmap::createWithRoadmap(p, r));
+  PathVectorPtr_t pv(planner->solve());
+  BOOST_CHECK(pv);
+  BOOST_CHECK(pv->numberPaths() == 4);
+  q[0] = 0; q[1] = 0;
+  BOOST_CHECK(pv->pathAtRank(0)->initial() == q);
+  q[0] = 1; q[1] = 0;
+  BOOST_CHECK(pv->pathAtRank(0)->end() == q);
+  BOOST_CHECK(pv->pathAtRank(1)->initial() == q);
+  q[0] = .5; q[1] = .9;
+  BOOST_CHECK(pv->pathAtRank(1)->end() == q);
+  BOOST_CHECK(pv->pathAtRank(2)->initial() == q);
+  q[0] = 1.5; q[1] = 2.9;
+  BOOST_CHECK(pv->pathAtRank(2)->end() == q);
+  BOOST_CHECK(pv->pathAtRank(3)->initial() == q);
+  q[0] = 2.5; q[1] = 2.9;
+  BOOST_CHECK(pv->pathAtRank(3)->end() == q);
 
   // Check that memory if well deallocated.
   std::list<ConnectedComponentWkPtr_t> ccs;


### PR DESCRIPTION
This planner searches for a path in the roadmap provided at construction, without modifying the roadmap. This particularly useful for applications where the roadmap is built from an external algorithm like in inspection path planning for instance.
