### PR TITLE
[Cost] Add missing header.

### DIFF
--- a/include/hpp/core/path/cost.hh
+++ b/include/hpp/core/path/cost.hh
@@ -29,7 +29,8 @@
 #ifndef HPP_CORE_PATH_COST_HH
 #define HPP_CORE_PATH_COST_HH
 
-#include <hpp/core/path/cost.hh>
+#include <hpp/core/config.hh>
+#include <hpp/core/path.hh>
 
 namespace hpp {
 namespace core {


### PR DESCRIPTION
Follows https://github.com/humanoid-path-planner/hpp-core/pull/375.
