### PR TITLE
Reintroduce kd tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,8 @@ set(${PROJECT_NAME}_SOURCES
     src/path-validation/no-validation.hh
     src/nearest-neighbor/basic.hh #
     src/nearest-neighbor/basic.cc #
-    # src/nearest-neighbor/k-d-tree.cc # src/nearest-neighbor/k-d-tree.hh #
+    src/nearest-neighbor/k-d-tree.cc #
+    src/nearest-neighbor/k-d-tree.hh #
     src/nearest-neighbor/serialization.cc #
     src/node.cc #
     src/parameter.cc #

--- a/include/hpp/core/fwd.hh
+++ b/include/hpp/core/fwd.hh
@@ -278,12 +278,12 @@ typedef shared_ptr<ReedsShepp> ReedsSheppPtr_t;
 }  // namespace distance
 
 class NearestNeighbor;
-typedef NearestNeighbor* NearestNeighborPtr_t;
+typedef shared_ptr<NearestNeighbor> NearestNeighborPtr_t;
 namespace nearestNeighbor {
 class Basic;
 class KDTree;
-typedef KDTree* KDTreePtr_t;
-typedef Basic* BasicPtr_t;
+typedef shared_ptr<KDTree> KDTreePtr_t;
+typedef shared_ptr<Basic> BasicPtr_t;
 }  // namespace nearestNeighbor
 
 namespace pathOptimization {

--- a/src/nearest-neighbor/k-d-tree.cc
+++ b/src/nearest-neighbor/k-d-tree.cc
@@ -32,11 +32,12 @@
 #include <fstream>
 #include <hpp/core/distance.hh>
 #include <hpp/core/node.hh>
-#include <hpp/core/weighed-distance.hh>
 #include <hpp/pinocchio/device.hh>
+#include <hpp/pinocchio/joint-collection.hh>
 #include <hpp/pinocchio/joint.hh>
 #include <hpp/util/debug.hh>
 #include <iostream>
+#include <pinocchio/multibody/model.hpp>
 #include <stdexcept>
 
 using namespace std;
@@ -45,7 +46,7 @@ namespace hpp {
 namespace core {
 namespace nearestNeighbor {
 // Constructor with the mother tree node (same bounds)
-KDTree::KDTree(const KDTreePtr_t mother, size_type splitDim)
+KDTree::KDTree(const KDTreePtr_t& mother, size_type splitDim)
     : robot_(mother->robot_),
       dim_(mother->dim_),
       distance_(mother->distance_),
@@ -73,21 +74,17 @@ KDTree::KDTree(const DevicePtr_t& robot, const DistancePtr_t& distance,
       lowerBounds_(),
       supChild_(),
       infChild_() {
-  JointVector_t jointVector = robot_->getJointVector();
   if (!distance_) {
     // create a weighed distance with unit weighs.
-    distance_ = WeighedDistance::createWithWeight(
-        robot_, std::vector<value_type>(jointVector.size(), 1.0));
+    vector_t ones(robot_->model().njoints);
+    ones.fill(1.0);
+    distance_ = WeighedDistance::createWithWeight(robot_, ones);
   }
-  size_type i = 0;
   // Fill vector of weights. index of vector is configuration coordinate
   // and not joint rank in robot.
-  for (JointVector_t::const_iterator itJoint = jointVector.begin();
-       itJoint != jointVector.end(); ++itJoint) {
-    weights_
-        .segment((*itJoint)->rankInConfiguration(), (*itJoint)->configSize())
-        .setConstant(distance_->getWeight(i));
-    ++i;
+  for (int i = 1; i < robot_->model().njoints; ++i) {
+    weights_.segment(robot_->model().idx_qs[i], robot_->model().joints[i].nq())
+        .setConstant(distance_->getWeight(i - 1));
   }
   this->findDeviceBounds();
   dim_ = lowerBounds_.size();
@@ -100,7 +97,7 @@ KDTree::~KDTree() { clear(); }
 
 // find the leaf node in the tree for the configuration of the node
 KDTreePtr_t KDTree::findLeaf(const NodePtr_t& node) {
-  KDTreePtr_t CurrentTree = this;
+  KDTreePtr_t CurrentTree = shared_from_this();
   CurrentTree->nodesMap_[node->connectedComponent()];
   while (CurrentTree->supChild_ != NULL && CurrentTree->infChild_ != NULL) {
     if ((node->configuration())[CurrentTree->supChild_->splitDim_] >
@@ -135,17 +132,7 @@ void KDTree::addNode(const NodePtr_t& node) {
   }
 }
 
-void KDTree::clear() {
-  nodesMap_.clear();
-  if (infChild_ != NULL) {
-    delete infChild_;
-    infChild_ = NULL;
-  }
-  if (supChild_ != NULL) {
-    delete supChild_;
-    supChild_ = NULL;
-  }
-}
+void KDTree::clear() { nodesMap_.clear(); }
 
 void KDTree::split() {
   if (infChild_ != NULL || supChild_ != NULL) {
@@ -185,34 +172,24 @@ void KDTree::split() {
   }
 
   // Compute median value of coordinates
-  infChild_ = new KDTree(this, splitDim);
+  infChild_ = std::make_shared<KDTree>(shared_from_this(), splitDim);
   infChild_->upperBounds_[splitDim] =
       (actualUpper[splitDim] + actualLower[splitDim]) / 2;
-  supChild_ = new KDTree(this, splitDim);
+  supChild_ = std::make_shared<KDTree>(shared_from_this(), splitDim);
   supChild_->lowerBounds_[splitDim] =
       (actualUpper[splitDim] + actualLower[splitDim]) / 2;
 }
 
 // get joints limits
 void KDTree::findDeviceBounds() {
-  JointVector_t jv = robot_->getJointVector();
-  int i = 0;
   upperBounds_.resize(robot_->configSize());
   lowerBounds_.resize(robot_->configSize());
-  for (JointVector_t::const_iterator itJoint = jv.begin(); itJoint != jv.end();
-       ++itJoint) {
-    for (size_type rank = 0; rank < (*itJoint)->configSize(); rank++) {
-      upperBounds_[i] = (*itJoint)->upperBound(rank);
-      lowerBounds_[i] = (*itJoint)->lowerBound(rank);
-      ++i;
-    }
-  }
+  int nq = robot_->model().nq;
+  upperBounds_.head(nq) = robot_->model().upperPositionLimit;
+  lowerBounds_.head(nq) = robot_->model().lowerPositionLimit;
   const pinocchio::ExtraConfigSpace& ecs = robot_->extraConfigSpace();
-  for (size_type rank = 0; rank < ecs.dimension(); ++rank) {
-    upperBounds_[i] = ecs.upper(rank);
-    lowerBounds_[i] = ecs.lower(rank);
-    ++i;
-  }
+  upperBounds_.segment(nq, ecs.dimension()) = ecs.upper();
+  lowerBounds_.segment(nq, ecs.dimension()) = ecs.lower();
 }
 
 value_type KDTree::distanceToBox(ConfigurationIn_t configuration) {
@@ -266,18 +243,26 @@ NodePtr_t KDTree::search(const NodePtr_t& node,
 Nodes_t KDTree::KnearestSearch(const NodePtr_t&, const ConnectedComponentPtr_t&,
                                const std::size_t, value_type&) {
   assert(false && "K-nearest neighbor in KD-tree: unimplemented features");
+  return Nodes_t();
 }
 
 Nodes_t KDTree::KnearestSearch(ConfigurationIn_t,
                                const ConnectedComponentPtr_t&,
                                const std::size_t, value_type&) {
   assert(false && "K-nearest neighbor in KD-tree: unimplemented features");
+  return Nodes_t();
 }
 
-Nodes_t KDTree::KnearestSearch(ConfigurationIn_t configuration,
-                               const RoadmapPtr_t& roadmap, const std::size_t K,
-                               value_type& distance) {
+Nodes_t KDTree::KnearestSearch(ConfigurationIn_t, const RoadmapPtr_t&,
+                               const std::size_t, value_type&) {
   assert(false && "K-nearest neighbor in KD-tree: unimplemented features");
+  return Nodes_t();
+}
+
+NodeVector_t KDTree::withinBall(ConfigurationIn_t,
+                                const ConnectedComponentPtr_t&, value_type) {
+  assert(false && "withinBall in KD-tree: unimplemented features");
+  return NodeVector_t();
 }
 
 void KDTree::search(value_type boxDistance, value_type& minDistance,

--- a/src/nearest-neighbor/k-d-tree.hh
+++ b/src/nearest-neighbor/k-d-tree.hh
@@ -33,17 +33,20 @@
 #include <hpp/core/distance.hh>
 #include <hpp/core/nearest-neighbor.hh>
 #include <hpp/core/node.hh>
+#include <hpp/core/weighed-distance.hh>
 #include <hpp/pinocchio/device.hh>
 #include <hpp/pinocchio/joint.hh>
+#include <memory>
 
 namespace hpp {
 namespace core {
 namespace nearestNeighbor {
 // Built an k-dimentional tree for the nearest neighbour research
-class KDTree : public NearestNeighbor {
+class KDTree : public NearestNeighbor,
+               public std::enable_shared_from_this<KDTree> {
  public:
   // constructor
-  KDTree(const KDTreePtr_t mother, size_type splitDim);
+  KDTree(const KDTreePtr_t& mother, size_type splitDim);
   KDTree(const DevicePtr_t& robot, const DistancePtr_t& distance_,
          int bucketSize);
 
@@ -86,6 +89,11 @@ class KDTree : public NearestNeighbor {
                                  const RoadmapPtr_t& roadmap,
                                  const std::size_t K, value_type& distance);
 
+  /// \return all the nodes closer than \c maxDistance to \c configuration
+  /// within \c connectedComponent.
+  virtual NodeVector_t withinBall(ConfigurationIn_t configuration,
+                                  const ConnectedComponentPtr_t& cc,
+                                  value_type maxDistance);
   // merge two connected components in the whole tree
   void merge(ConnectedComponentPtr_t cc1, ConnectedComponentPtr_t cc2);
   // Get distance function

--- a/src/path-optimization/spline-gradient-based/joint-bounds.hh
+++ b/src/path-optimization/spline-gradient-based/joint-bounds.hh
@@ -51,7 +51,7 @@ struct JointBoundConstraintAlgo<VectorSpaceOperation<Size, rot> > {
                   vectorIn_t neutral, matrix_t& A, vector_t& b,
                   size_type& row) {
     // size_type row;
-    for (std::size_t i = 0; i < Size; ++i) {
+    for (std::size_t i = 0; i < (std::size_t)Size; ++i) {
       if (!std::isinf(low(i))) {
         // row = A.rows();
         // A.conservativeResize(A.rows() + 1, A.cols());

--- a/src/roadmap.cc
+++ b/src/roadmap.cc
@@ -79,10 +79,7 @@ void Roadmap::nearestNeighbor(NearestNeighborPtr_t nearestNeighbor) {
         "The roadmap must be empty before setting a new NearestNeighbor "
         "object.");
   }
-  if (nearestNeighbor != NULL) {
-    delete nearestNeighbor_;
-    nearestNeighbor_ = nearestNeighbor;
-  }
+  nearestNeighbor_ = nearestNeighbor;
 }
 
 void Roadmap::clear() {

--- a/src/roadmap.cc
+++ b/src/roadmap.cc
@@ -62,10 +62,7 @@ Roadmap::Roadmap(const DistancePtr_t& distance, const DevicePtr_t&)
       goalNodes_(),
       nearestNeighbor_(new nearestNeighbor::Basic(distance)) {}
 
-Roadmap::~Roadmap() {
-  clear();
-  delete nearestNeighbor_;
-}
+Roadmap::~Roadmap() { clear(); }
 
 const ConnectedComponents_t& Roadmap::connectedComponents() const {
   return connectedComponents_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,7 +67,7 @@ if(OPENMP_FOUND)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif()
 
-# ADD_TESTCASE (test-kdTree FALSE)
+add_testcase(test-kdTree FALSE)
 add_testcase(roadmap-1 FALSE)
 add_testcase(test-intervals FALSE)
 add_testcase(test-solid-solid-collision FALSE)

--- a/tests/test-kdTree.cc
+++ b/tests/test-kdTree.cc
@@ -33,61 +33,63 @@
 
 // #include <Eigen/Core>
 
+#include <hpp/core/configuration-shooter/uniform.hh>
 #include <hpp/core/connected-component.hh>
-#include <hpp/core/fwd.hh>
 #include <hpp/core/node.hh>
+#include <hpp/core/problem.hh>
 #include <hpp/core/roadmap.hh>
 #include <hpp/core/steering-method/straight.hh>
 #include <hpp/core/weighed-distance.hh>
-#include <hpp/model/device.hh>
 #include <hpp/pinocchio/configuration.hh>
 #include <hpp/pinocchio/device.hh>
+#include <hpp/pinocchio/joint-collection.hh>
 #include <hpp/pinocchio/joint.hh>
 #include <hpp/util/debug.hh>
 
 #include "../src/nearest-neighbor/basic.hh"
 #include "../src/nearest-neighbor/k-d-tree.hh"
-#include "hpp/core/basic-configuration-shooter.hh"
 
 #define BOOST_TEST_MODULE kdTree
 #include <boost/test/included/unit_test.hpp>
 #include <pinocchio/multibody/geometry.hpp>
 #include <pinocchio/multibody/model.hpp>
 
-using namespace hpp;
-using namespace core;
-using namespace pinocchio;
-using namespace std;
+using hpp::pinocchio::value_type;
 using ::pinocchio::JointIndex;
 using ::pinocchio::JointModelRUBZ;
 using ::pinocchio::JointModelSpherical;
 using ::pinocchio::JointModelTranslation;
 
+using hpp::core::ConfigurationShooterPtr_t;
+using hpp::core::NodePtr_t;
+using hpp::core::PathPtr_t;
+using hpp::core::Problem;
+using hpp::core::ProblemPtr_t;
+using hpp::core::Roadmap;
+using hpp::core::RoadmapPtr_t;
+using hpp::core::SteeringMethodPtr_t;
+using hpp::core::WeighedDistance;
+using hpp::core::WeighedDistancePtr_t;
+using hpp::core::nearestNeighbor::KDTree;
+using hpp::core::nearestNeighbor::KDTreePtr_t;
+
+using hpp::pinocchio::Configuration_t;
+using hpp::pinocchio::Device;
+using hpp::pinocchio::DevicePtr_t;
+using hpp::pinocchio::displayConfig;
+using hpp::pinocchio::GeomModel;
+using hpp::pinocchio::GeomModelPtr_t;
+using hpp::pinocchio::Model;
+using hpp::pinocchio::ModelPtr_t;
+using hpp::pinocchio::Transform3s;
+
 BOOST_AUTO_TEST_SUITE(test_hpp_core)
 
 BOOST_AUTO_TEST_CASE(kdTree) {
   // Build Device
-  /* DevicePtr_t robot = Device::create("robot");
-   JointPtr_t transJoint = new JointTranslation <3> (Transform3s());
-   transJoint->isBounded (0, true);
-   transJoint->lowerBound(0,-3.);
-   transJoint->upperBound(0, 3.);
-   transJoint->isBounded (1, true);
-   transJoint->lowerBound(1,-3.);
-   transJoint->upperBound(1, 3.);
-   transJoint->isBounded (2, true);
-   transJoint->lowerBound(2,-3.);
-   transJoint->upperBound(2, 3.);
-   JointPtr_t so3Joint = new JointSO3(Transform3s());
-   JointPtr_t so2Joint = new jointRotation::UnBounded
-     (Transform3s (coal::Vec3f (0, 0, 1)));
-   robot->rootJoint(transJoint);
-   transJoint->addChildJoint (so3Joint);
-   so3Joint->addChildJoint (so2Joint);
- */
   DevicePtr_t robot = Device::create("robot");
   ModelPtr_t m = ModelPtr_t(new Model());
-  GeomModelPtr_t gm = GeomModelPtr_t(new GeomModel());
+  GeomModelPtr_t gm = GeomModelPtr_t(new hpp::pinocchio::GeomModel());
   robot->setModel(m);
   robot->setGeomModel(gm);
   const std::string& name = robot->name();
@@ -146,22 +148,22 @@ BOOST_AUTO_TEST_CASE(kdTree) {
   WeighedDistancePtr_t distance = WeighedDistance::create(robot);
   problem->distance(distance);
   ConfigurationShooterPtr_t confShoot = problem->configurationShooter();
-  nearestNeighbor::KDTree kdTree(robot, distance, 30);
-  nearestNeighbor::Basic basic(distance);
-  SteeringMethodPtr_t sm = steeringMethod::Straight::create(problem);
+  KDTreePtr_t kdTree(std::make_shared<KDTree>(robot, distance, 30));
+  hpp::core::nearestNeighbor::Basic basic(distance);
+  SteeringMethodPtr_t sm = hpp::core::steeringMethod::Straight::create(problem);
 
   // Add 4 connectedComponents with 2000 nodes each
-  ConfigurationPtr_t configuration;
+  Configuration_t configuration;
   NodePtr_t node;
   NodePtr_t rootNode[4];
   RoadmapPtr_t roadmap = Roadmap::create(distance, robot);
-  roadmap->nearestNeighbor(&kdTree);
+  roadmap->nearestNeighbor(kdTree);
   for (int i = 0; i < 4; i++) {
     configuration = confShoot->shoot();
     rootNode[i] = roadmap->addNode(configuration);
     for (int j = 1; j < 200; j++) {
       configuration = confShoot->shoot();
-      PathPtr_t path = (*sm)(*(rootNode[i]->configuration()), *configuration);
+      PathPtr_t path = (*sm)(rootNode[i]->configuration(), configuration);
       node = roadmap->addNodeAndEdges(rootNode[i], configuration, path);
       basic.addNode(node);
     }
@@ -183,7 +185,7 @@ BOOST_AUTO_TEST_CASE(kdTree) {
           configuration, rootNode[i]->connectedComponent(), minDistance2);
       BOOST_CHECK(node1 == node2);
       BOOST_CHECK(fabs(minDistance1 - minDistance2) < 1e-15);
-      std::cout << displayConfig(*(node1->configuration())) << std::endl;
+      std::cout << displayConfig(node1->configuration()) << std::endl;
       std::cout << minDistance1 << "," << minDistance2 << ","
                 << minDistance1 - minDistance2 << std::endl;
     }


### PR DESCRIPTION
This PR brings 2 modifications:
  - it handles NearestNeighbor abstract class and its derived class with shared pointer instead of raw pointers.
  - it reintroduce KDTree as a nearest neighbor management.

The first change is a breaking change, but it does not affect depending packages in HPP space.
