### PR TITLE
Fix computation of path extraction

### DIFF
--- a/include/hpp/core/kinodynamic-oriented-path.hh
+++ b/include/hpp/core/kinodynamic-oriented-path.hh
@@ -134,6 +134,10 @@ class HPP_CORE_DLLAPI KinodynamicOrientedPath : public KinodynamicPath {
   void ignoreZValue(bool ignoreZValue) { ignoreZValue_ = ignoreZValue; }
 
  protected:
+  // Make this method accessible to this class
+  void constraints(const ConstraintSetPtr_t& constr) {
+    parent_t::constraints(constr);
+  }
   /// Print path in a stream
   virtual std::ostream& print(std::ostream& os) const {
     os << "KinodynamicOrientedPath:" << std::endl;

--- a/include/hpp/core/kinodynamic-path.hh
+++ b/include/hpp/core/kinodynamic-path.hh
@@ -152,6 +152,11 @@ class HPP_CORE_DLLAPI KinodynamicPath : public StraightPath {
   vector_t getA1() { return a1_; }
 
  protected:
+  // Make this method accessible to this class
+  void constraints(const ConstraintSetPtr_t& constr) {
+    this->parent_t::constraints(constr);
+  }
+
   /// Print path in a stream
   virtual std::ostream& print(std::ostream& os) const {
     os << "KinodynamicPath:" << std::endl;

--- a/src/extracted-path.hh
+++ b/src/extracted-path.hh
@@ -66,7 +66,8 @@ class ExtractedPath : public Path {
     ExtractedPathPtr_t shPtr(ptr);
     ptr->init(shPtr);
     if (path->constraints()) {
-      ConstraintSetPtr_t cs(HPP_DYNAMIC_PTR_CAST(ConstraintSet, path->constraints()->copy()));
+      ConstraintSetPtr_t cs(
+          HPP_DYNAMIC_PTR_CAST(ConstraintSet, path->constraints()->copy()));
       assert(cs);
       shPtr->constraints(cs);
     }

--- a/src/extracted-path.hh
+++ b/src/extracted-path.hh
@@ -65,6 +65,11 @@ class ExtractedPath : public Path {
     ExtractedPath* ptr = new ExtractedPath(*path);
     ExtractedPathPtr_t shPtr(ptr);
     ptr->init(shPtr);
+    if (path->constraints()) {
+      ConstraintSetPtr_t cs(HPP_DYNAMIC_PTR_CAST(ConstraintSet, path->constraints()->copy()));
+      assert(cs);
+      shPtr->constraints(cs);
+    }
     return shPtr;
   }
 

--- a/src/kinodynamic-path.cc
+++ b/src/kinodynamic-path.cc
@@ -280,8 +280,9 @@ PathPtr_t KinodynamicPath::impl_extract(const interval_t& subInterval) const {
       cs = HPP_DYNAMIC_PTR_CAST(ConstraintSet, Path::constraints()->copy());
       assert(cs);
     }
-    PathPtr_t result = StraightPath::create(device_, (eval(subInterval.first, success)),
-					    (eval(subInterval.first, success)), 0., cs);
+    PathPtr_t result =
+        StraightPath::create(device_, (eval(subInterval.first, success)),
+                             (eval(subInterval.first, success)), 0., cs);
     return result;
   }
 

--- a/src/kinodynamic-path.cc
+++ b/src/kinodynamic-path.cc
@@ -52,7 +52,7 @@ KinodynamicPath::KinodynamicPath(const DevicePtr_t& device,
       vLim_(vLim) {
   assert(device);
   assert(length >= 0);
-  assert(!constraints());
+  assert(!Path::constraints());
   hppDout(notice, "Create kinodynamic path with values : ");
   hppDout(notice, "a1 = " << pinocchio::displayConfig(a1_));
   hppDout(notice, "t0 = " << pinocchio::displayConfig(t0_));
@@ -275,8 +275,14 @@ PathPtr_t KinodynamicPath::impl_extract(const interval_t& subInterval) const {
   value_type l = fabs(subInterval.second - subInterval.first);
   if (l <= 0) {
     hppDout(notice, "Call Extract with a length null");
-    return StraightPath::create(device_, (eval(subInterval.first, success)),
-                                (eval(subInterval.first, success)), 0.);
+    ConstraintSetPtr_t cs;
+    if (Path::constraints()) {
+      cs = HPP_DYNAMIC_PTR_CAST(ConstraintSet, Path::constraints()->copy());
+      assert(cs);
+    }
+    PathPtr_t result = StraightPath::create(device_, (eval(subInterval.first, success)),
+					    (eval(subInterval.first, success)), 0., cs);
+    return result;
   }
 
   hppDout(notice, "%% EXTRACT PATH : path interval : "
@@ -377,7 +383,7 @@ PathPtr_t KinodynamicPath::impl_extract(const interval_t& subInterval) const {
 
   }  // for all joints
   PathPtr_t result = KinodynamicPath::create(device_, q1, q2, l, a1, t0, t1, tv,
-                                             t2, vLim_, constraints());
+                                             t2, vLim_, Path::constraints());
   return result;
 }
 

--- a/src/path-vector.cc
+++ b/src/path-vector.cc
@@ -175,7 +175,8 @@ PathPtr_t PathVector::impl_extract(const interval_t& subInterval) const {
   assert(!timeParameterization());
   PathVectorPtr_t path = create(outputSize(), outputDerivativeSize());
   if (constraints()) {
-    ConstraintSetPtr_t cs(HPP_DYNAMIC_PTR_CAST(ConstraintSet, constraints()->copy()));
+    ConstraintSetPtr_t cs(
+        HPP_DYNAMIC_PTR_CAST(ConstraintSet, constraints()->copy()));
     assert(cs);
     path->constraints(cs);
   }

--- a/src/path-vector.cc
+++ b/src/path-vector.cc
@@ -174,6 +174,11 @@ void PathVector::impl_velocityBound(vectorOut_t bound, const value_type& param0,
 PathPtr_t PathVector::impl_extract(const interval_t& subInterval) const {
   assert(!timeParameterization());
   PathVectorPtr_t path = create(outputSize(), outputDerivativeSize());
+  if (constraints()) {
+    ConstraintSetPtr_t cs(HPP_DYNAMIC_PTR_CAST(ConstraintSet, constraints()->copy()));
+    assert(cs);
+    path->constraints(cs);
+  }
   bool reversed = subInterval.first > subInterval.second ? true : false;
 
   value_type localtinit, localtend;

--- a/src/steering-method/constant-curvature.cc
+++ b/src/steering-method/constant-curvature.cc
@@ -92,6 +92,11 @@ ConstantCurvaturePtr_t ConstantCurvature::createCopy(
   ConstantCurvature* ptr(new ConstantCurvature(*other));
   ConstantCurvaturePtr_t shPtr(ptr);
   ptr->init(shPtr);
+  if (other->constraints()) {
+    ConstraintSetPtr_t cs = HPP_DYNAMIC_PTR_CAST(ConstraintSet, other->constraints()->copy());
+    assert(cs);
+    shPtr->constraints(cs);
+  }
   return shPtr;
 }
 

--- a/src/steering-method/constant-curvature.cc
+++ b/src/steering-method/constant-curvature.cc
@@ -29,6 +29,8 @@
 
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/weak_ptr.hpp>
+#include <hpp/constraints/solver/by-substitution.hh>
+#include <hpp/core/config-projector.hh>
 #include <hpp/core/steering-method/constant-curvature.hh>
 #include <hpp/pinocchio/configuration.hh>
 #include <hpp/pinocchio/device.hh>
@@ -426,6 +428,12 @@ PathPtr_t ConstantCurvature::reverse() const {
   result->curveLength_ = -curveLength_;
   result->timeRange(interval_t(0, length()));
   result->forward_ = curveLength_ < 0 ? 1 : -1;
+  // If some path constraints are time-varying, we need to update the time interval of
+  // the right hand side
+  if (result->constraints() && result->constraints()->configProjector()) {
+    result->constraints()->configProjector()->solver() =
+      constraints()->configProjector()->solver().extract(std::make_pair(length(), 0));
+  }
   return result;
 }
 

--- a/src/steering-method/constant-curvature.cc
+++ b/src/steering-method/constant-curvature.cc
@@ -93,7 +93,8 @@ ConstantCurvaturePtr_t ConstantCurvature::createCopy(
   ConstantCurvaturePtr_t shPtr(ptr);
   ptr->init(shPtr);
   if (other->constraints()) {
-    ConstraintSetPtr_t cs = HPP_DYNAMIC_PTR_CAST(ConstraintSet, other->constraints()->copy());
+    ConstraintSetPtr_t cs =
+        HPP_DYNAMIC_PTR_CAST(ConstraintSet, other->constraints()->copy());
     assert(cs);
     shPtr->constraints(cs);
   }
@@ -433,11 +434,12 @@ PathPtr_t ConstantCurvature::reverse() const {
   result->curveLength_ = -curveLength_;
   result->timeRange(interval_t(0, length()));
   result->forward_ = curveLength_ < 0 ? 1 : -1;
-  // If some path constraints are time-varying, we need to update the time interval of
-  // the right hand side
+  // If some path constraints are time-varying, we need to update the time
+  // interval of the right hand side
   if (result->constraints() && result->constraints()->configProjector()) {
     result->constraints()->configProjector()->solver() =
-      constraints()->configProjector()->solver().extract(std::make_pair(length(), 0));
+        constraints()->configProjector()->solver().extract(
+            std::make_pair(length(), 0));
   }
   return result;
 }

--- a/src/straight-path.cc
+++ b/src/straight-path.cc
@@ -157,7 +157,7 @@ PathPtr_t StraightPath::impl_extract(const interval_t& subInterval) const {
     cs = HPP_DYNAMIC_PTR_CAST(ConstraintSet, constraints()->copy());
   }
   StraightPathPtr_t result =
-    StraightPath::create(space_, q1, q2, interval_t(0, l), cs);
+      StraightPath::create(space_, q1, q2, interval_t(0, l), cs);
   return result;
 }
 

--- a/src/straight-path.cc
+++ b/src/straight-path.cc
@@ -152,8 +152,12 @@ PathPtr_t StraightPath::impl_extract(const interval_t& subInterval) const {
   if (!success)
     throw projection_error(
         "Failed to apply constraints in StraightPath::extract");
+  ConstraintSetPtr_t cs;
+  if (constraints()) {
+    cs = HPP_DYNAMIC_PTR_CAST(ConstraintSet, constraints()->copy());
+  }
   StraightPathPtr_t result =
-      StraightPath::create(space_, q1, q2, interval_t(0, l), constraints());
+    StraightPath::create(space_, q1, q2, interval_t(0, l), cs);
   return result;
 }
 

--- a/tests/test-path-extraction.cc
+++ b/tests/test-path-extraction.cc
@@ -29,10 +29,10 @@
 
 #define BOOST_TEST_MODULE path_extraction
 
-#include <cmath>
 #include <coal/math/transform.h>
 
 #include <boost/test/included/unit_test.hpp>
+#include <cmath>
 #include <hpp/constraints/affine-function.hh>
 #include <hpp/constraints/implicit.hh>
 #include <hpp/core/config-projector.hh>
@@ -55,10 +55,10 @@ using hpp::constraints::DifferentiableFunctionPtr_t;
 using hpp::constraints::Identity;
 using hpp::constraints::Implicit;
 using hpp::constraints::ImplicitPtr_t;
-using hpp::core::ConstraintSet;
-using hpp::core::ConstraintSetPtr_t;
 using hpp::core::ConfigProjector;
 using hpp::core::ConfigProjectorPtr_t;
+using hpp::core::ConstraintSet;
+using hpp::core::ConstraintSetPtr_t;
 using hpp::core::InterpolatedPath;
 using hpp::pinocchio::Configuration_t;
 using hpp::pinocchio::ConfigurationOut_t;
@@ -75,7 +75,7 @@ typedef std::shared_ptr<LocalPath> LocalPathPtr_t;
 
 // Linear interpolation between two points
 class LocalPath : public Path {
-  public:
+ public:
   virtual ~LocalPath() {}
   virtual bool impl_compute(ConfigurationOut_t configuration,
                             value_type t) const {
@@ -95,7 +95,8 @@ class LocalPath : public Path {
 
   // Create a linear interpolation between q1 and q2
   static LocalPathPtr_t create(const interval_t& interval, ConfigurationIn_t q1,
-			       ConfigurationIn_t q2, ConstraintSetPtr_t constraints) {
+                               ConfigurationIn_t q2,
+                               ConstraintSetPtr_t constraints) {
     LocalPath* ptr(new LocalPath(interval, q1, q2, constraints));
     LocalPathPtr_t shPtr(ptr);
     ptr->init(shPtr);
@@ -129,10 +130,9 @@ class LocalPath : public Path {
     q2_[0] = interval.second;
   }
 
-  LocalPath(const interval_t& interval, ConfigurationIn_t q1, ConfigurationIn_t q2,
-	    const ConstraintSetPtr_t& constraints) :
-    Path(interval, q1.size(), q1.size(), constraints), q1_(q1), q2_(q2) {
-  }
+  LocalPath(const interval_t& interval, ConfigurationIn_t q1,
+            ConfigurationIn_t q2, const ConstraintSetPtr_t& constraints)
+      : Path(interval, q1.size(), q1.size(), constraints), q1_(q1), q2_(q2) {}
 
   LocalPath(const LocalPath& other)
       : Path(other), q1_(other.q1_), q2_(other.q2_) {}
@@ -223,26 +223,26 @@ BOOST_AUTO_TEST_CASE(path_extraction_2) {
 }
 
 class Rhs : public DifferentiableFunction {
-public:
+ public:
   static DifferentiableFunctionPtr_t create(value_type t0) {
     return DifferentiableFunctionPtr_t(new Rhs(t0));
   }
-protected:
-  Rhs(value_type t0) : DifferentiableFunction(1, 1, LiegroupSpace::R2(), "rhs"), t0_(t0) {
-  }
-  void impl_compute(LiegroupElementRef result,
-		    vectorIn_t argument) const {
+
+ protected:
+  Rhs(value_type t0)
+      : DifferentiableFunction(1, 1, LiegroupSpace::R2(), "rhs"), t0_(t0) {}
+  void impl_compute(LiegroupElementRef result, vectorIn_t argument) const {
     value_type t = argument[0] + t0_;
     result.vector()[0] = cos(t);
     result.vector()[1] = sin(t);
   }
   void impl_jacobian(matrixOut_t jacobian, vectorIn_t arg) const {
     value_type t = arg[0];
-    jacobian(0,0) = -sin(t);
-    jacobian(1,0) =  cos(t);
+    jacobian(0, 0) = -sin(t);
+    jacobian(1, 0) = cos(t);
   }
   value_type t0_;
-}; // class Rhs
+};  // class Rhs
 
 BOOST_AUTO_TEST_CASE(path_extraction_3) {
   // Build planar robot with 2 prismatic joints.
@@ -253,33 +253,44 @@ BOOST_AUTO_TEST_CASE(path_extraction_3) {
       "  <link name=\"lx\"/>\n"
       "  <link name=\"ly\"/>\n"
       "  <joint name=\"px\" type=\"prismatic\">\n"
-      "    <limit effort=\"1.0\" lower=\"-2.0\" upper=\"2.0\" velocity=\"2.0\"/>\n"
+      "    <limit effort=\"1.0\" lower=\"-2.0\" upper=\"2.0\" "
+      "velocity=\"2.0\"/>\n"
       "    <axis xyz=\"1 0 0\"/>\n"
       "    <parent link=\"base_link\"/>\n"
       "    <child link=\"lx\"/>\n"
       "  </joint>\n"
       "  <joint name=\"py\" type=\"prismatic\">\n"
-      "    <limit effort=\"1.0\" lower=\"-2.0\" upper=\"2.0\" velocity=\"2.0\"/>\n"
+      "    <limit effort=\"1.0\" lower=\"-2.0\" upper=\"2.0\" "
+      "velocity=\"2.0\"/>\n"
       "    <axis xyz=\"0 1 0\"/>"
       "    <parent link=\"lx\"/>\n"
       "    <child link=\"ly\"/>\n"
       "  </joint>\n"
       "</robot>");
 
-  hpp::pinocchio::urdf::loadModelFromString(robot, 0, "robot", "anchor", urdfString, "");
-  vector2_t q0; q0 << 1, 0;
-  vector2_t q1; q1 << 0, 1;
-  vector2_t q2; q2 << -1, 0;
-  vector2_t q3; q3 << 0, -1;
+  hpp::pinocchio::urdf::loadModelFromString(robot, 0, "robot", "anchor",
+                                            urdfString, "");
+  vector2_t q0;
+  q0 << 1, 0;
+  vector2_t q1;
+  q1 << 0, 1;
+  vector2_t q2;
+  q2 << -1, 0;
+  vector2_t q3;
+  q3 << 0, -1;
   ConstraintSetPtr_t cs0(ConstraintSet::create(robot, "cs0"));
   ConstraintSetPtr_t cs1(ConstraintSet::create(robot, "cs1"));
   ConstraintSetPtr_t cs2(ConstraintSet::create(robot, "cs2"));
   ConstraintSetPtr_t cs3(ConstraintSet::create(robot, "cs3"));
   value_type threshold = 1e-4;
-  ConfigProjectorPtr_t cp0(ConfigProjector::create(robot, "cp0", threshold, 50));
-  ConfigProjectorPtr_t cp1(ConfigProjector::create(robot, "cp1", threshold, 50));
-  ConfigProjectorPtr_t cp2(ConfigProjector::create(robot, "cp2", threshold, 50));
-  ConfigProjectorPtr_t cp3(ConfigProjector::create(robot, "cp3", threshold, 50));
+  ConfigProjectorPtr_t cp0(
+      ConfigProjector::create(robot, "cp0", threshold, 50));
+  ConfigProjectorPtr_t cp1(
+      ConfigProjector::create(robot, "cp1", threshold, 50));
+  ConfigProjectorPtr_t cp2(
+      ConfigProjector::create(robot, "cp2", threshold, 50));
+  ConfigProjectorPtr_t cp3(
+      ConfigProjector::create(robot, "cp3", threshold, 50));
   cs0->addConstraint(cp0);
   cs1->addConstraint(cp1);
   cs2->addConstraint(cp2);
@@ -291,30 +302,30 @@ BOOST_AUTO_TEST_CASE(path_extraction_3) {
   */
   ImplicitPtr_t f0(
       Implicit::create(Identity::create(LiegroupSpace::R2(), "I2"),
-          ComparisonTypes_t(2, hpp::constraints::Equality)));
+                       ComparisonTypes_t(2, hpp::constraints::Equality)));
   f0->rightHandSideFunction(Rhs::create(0));
   cp0->add(f0);
   ImplicitPtr_t f1(
       Implicit::create(Identity::create(LiegroupSpace::R2(), "I2"),
-          ComparisonTypes_t(2, hpp::constraints::Equality)));
-  f1->rightHandSideFunction(Rhs::create(M_PI/2));
+                       ComparisonTypes_t(2, hpp::constraints::Equality)));
+  f1->rightHandSideFunction(Rhs::create(M_PI / 2));
   cp1->add(f1);
   ImplicitPtr_t f2(
       Implicit::create(Identity::create(LiegroupSpace::R2(), "I2"),
-          ComparisonTypes_t(2, hpp::constraints::Equality)));
+                       ComparisonTypes_t(2, hpp::constraints::Equality)));
   f2->rightHandSideFunction(Rhs::create(M_PI));
   cp2->add(f2);
   ImplicitPtr_t f3(
       Implicit::create(Identity::create(LiegroupSpace::R2(), "I2"),
-          ComparisonTypes_t(2, hpp::constraints::Equality)));
-  f3->rightHandSideFunction(Rhs::create(3*M_PI/2));
+                       ComparisonTypes_t(2, hpp::constraints::Equality)));
+  f3->rightHandSideFunction(Rhs::create(3 * M_PI / 2));
   cp3->add(f3);
 
   // Create a constrained paths between qi and q{i+1}
-  PathPtr_t p0(LocalPath::create(std::make_pair(0, M_PI/2), q0, q1, cs0));
-  PathPtr_t p1(LocalPath::create(std::make_pair(0, M_PI/2), q1, q2, cs1));
-  PathPtr_t p2(LocalPath::create(std::make_pair(0, M_PI/2), q2, q3, cs2));
-  PathPtr_t p3(LocalPath::create(std::make_pair(0, M_PI/2), q3, q0, cs3));
+  PathPtr_t p0(LocalPath::create(std::make_pair(0, M_PI / 2), q0, q1, cs0));
+  PathPtr_t p1(LocalPath::create(std::make_pair(0, M_PI / 2), q1, q2, cs1));
+  PathPtr_t p2(LocalPath::create(std::make_pair(0, M_PI / 2), q2, q3, cs2));
+  PathPtr_t p3(LocalPath::create(std::make_pair(0, M_PI / 2), q3, q0, cs3));
   // Convert them into interpolated paths
   PathPtr_t ip0(InterpolatedPath::create(p0, robot, 4));
   PathPtr_t ip1(InterpolatedPath::create(p1, robot, 4));
@@ -326,23 +337,21 @@ BOOST_AUTO_TEST_CASE(path_extraction_3) {
   pv->appendPath(ip1);
   pv->appendPath(ip2);
   pv->appendPath(ip3);
-  PathPtr_t ep0(pv->extract(M_PI/4, 5*M_PI/4));
-   PathPtr_t ep1(ep0->reverse());
-  BOOST_CHECK_CLOSE(ep0->length(), M_PI,
-                    std::numeric_limits<float>::epsilon());
-  BOOST_CHECK_CLOSE(ep1->length(), M_PI,
-                    std::numeric_limits<float>::epsilon());
-  for (size_type i=0; i<=50; ++i) {
+  PathPtr_t ep0(pv->extract(M_PI / 4, 5 * M_PI / 4));
+  PathPtr_t ep1(ep0->reverse());
+  BOOST_CHECK_CLOSE(ep0->length(), M_PI, std::numeric_limits<float>::epsilon());
+  BOOST_CHECK_CLOSE(ep1->length(), M_PI, std::numeric_limits<float>::epsilon());
+  for (size_type i = 0; i <= 50; ++i) {
     bool success;
-    value_type s = ((value_type)i)*M_PI/50;
+    value_type s = ((value_type)i) * M_PI / 50;
     Configuration_t q = ep0->eval(s, success);
     assert(success);
-    BOOST_CHECK(fabs(q[0] - cos(M_PI/4 + s)) <= threshold);
-    BOOST_CHECK(fabs(q[1] - sin(M_PI/4 + s)) <= threshold);
+    BOOST_CHECK(fabs(q[0] - cos(M_PI / 4 + s)) <= threshold);
+    BOOST_CHECK(fabs(q[1] - sin(M_PI / 4 + s)) <= threshold);
     q = ep1->eval(s, success);
     assert(success);
-    BOOST_CHECK(fabs(q[0] - cos(5*M_PI/4 - s)) <= threshold);
-    BOOST_CHECK(fabs(q[1] - sin(5*M_PI/4 - s)) <= threshold);
+    BOOST_CHECK(fabs(q[0] - cos(5 * M_PI / 4 - s)) <= threshold);
+    BOOST_CHECK(fabs(q[1] - sin(5 * M_PI / 4 - s)) <= threshold);
   }
 }
 

--- a/tests/test-path-extraction.cc
+++ b/tests/test-path-extraction.cc
@@ -29,32 +29,54 @@
 
 #define BOOST_TEST_MODULE path_extraction
 
+#include <cmath>
 #include <coal/math/transform.h>
 
 #include <boost/test/included/unit_test.hpp>
+#include <hpp/constraints/affine-function.hh>
+#include <hpp/constraints/implicit.hh>
+#include <hpp/core/config-projector.hh>
+#include <hpp/core/constraint-set.hh>
+#include <hpp/core/interpolated-path.hh>
 #include <hpp/core/path-vector.hh>
 #include <hpp/core/problem.hh>
 #include <hpp/core/steering-method/straight.hh>
 #include <hpp/core/time-parameterization/polynomial.hh>
+#include <hpp/pinocchio/device.hh>
+#include <hpp/pinocchio/liegroup-space.hh>
+#include <hpp/pinocchio/urdf/util.hh>
 #include <pinocchio/fwd.hpp>
 
 BOOST_AUTO_TEST_SUITE(test_hpp_core)
 
+using hpp::constraints::ComparisonTypes_t;
+using hpp::constraints::DifferentiableFunction;
+using hpp::constraints::DifferentiableFunctionPtr_t;
+using hpp::constraints::Identity;
+using hpp::constraints::Implicit;
+using hpp::constraints::ImplicitPtr_t;
+using hpp::core::ConstraintSet;
+using hpp::core::ConstraintSetPtr_t;
+using hpp::core::ConfigProjector;
+using hpp::core::ConfigProjectorPtr_t;
+using hpp::core::InterpolatedPath;
 using hpp::pinocchio::Configuration_t;
 using hpp::pinocchio::ConfigurationOut_t;
 using hpp::pinocchio::Device;
 using hpp::pinocchio::DevicePtr_t;
 using hpp::pinocchio::JointConstPtr_t;
 using hpp::pinocchio::JointPtr_t;
+using hpp::pinocchio::LiegroupSpace;
 
 using namespace hpp::core;
 
 HPP_PREDEF_CLASS(LocalPath);
 typedef std::shared_ptr<LocalPath> LocalPathPtr_t;
 
+// Linear interpolation between two points
 class LocalPath : public Path {
- public:
-  virtual ~LocalPath() throw() {}
+  public:
+  virtual ~LocalPath() {}
   virtual bool impl_compute(ConfigurationOut_t configuration,
                             value_type t) const {
     value_type alpha(t - timeRange().first /
@@ -63,6 +85,7 @@ class LocalPath : public Path {
     return true;
   }
 
+  // Create a linear path interpolation between t_min and t_max
   static LocalPathPtr_t create(const interval_t& interval) {
     LocalPath* ptr(new LocalPath(interval));
     LocalPathPtr_t shPtr(ptr);
@@ -70,6 +93,14 @@ class LocalPath : public Path {
     return shPtr;
   }
 
+  // Create a linear interpolation between q1 and q2
+  static LocalPathPtr_t create(const interval_t& interval, ConfigurationIn_t q1,
+			       ConfigurationIn_t q2, ConstraintSetPtr_t constraints) {
+    LocalPath* ptr(new LocalPath(interval, q1, q2, constraints));
+    LocalPathPtr_t shPtr(ptr);
+    ptr->init(shPtr);
+    return shPtr;
+  }
   static LocalPathPtr_t createCopy(const LocalPathPtr_t& other) {
     LocalPath* ptr(new LocalPath(*other));
     LocalPathPtr_t shPtr(ptr);
@@ -96,6 +127,11 @@ class LocalPath : public Path {
   LocalPath(const interval_t& interval) : Path(interval, 1, 1), q1_(1), q2_(1) {
     q1_[0] = interval.first;
     q2_[0] = interval.second;
+  }
+
+  LocalPath(const interval_t& interval, ConfigurationIn_t q1, ConfigurationIn_t q2,
+	    const ConstraintSetPtr_t& constraints) :
+    Path(interval, q1.size(), q1.size(), constraints), q1_(q1), q2_(q2) {
   }
 
   LocalPath(const LocalPath& other)
@@ -184,6 +220,130 @@ BOOST_AUTO_TEST_CASE(path_extraction_2) {
                     std::numeric_limits<float>::epsilon());
   BOOST_CHECK_CLOSE(extracted->length(), tmax - tmin,
                     std::numeric_limits<float>::epsilon());
+}
+
+class Rhs : public DifferentiableFunction {
+public:
+  static DifferentiableFunctionPtr_t create(value_type t0) {
+    return DifferentiableFunctionPtr_t(new Rhs(t0));
+  }
+protected:
+  Rhs(value_type t0) : DifferentiableFunction(1, 1, LiegroupSpace::R2(), "rhs"), t0_(t0) {
+  }
+  void impl_compute(LiegroupElementRef result,
+		    vectorIn_t argument) const {
+    value_type t = argument[0] + t0_;
+    result.vector()[0] = cos(t);
+    result.vector()[1] = sin(t);
+  }
+  void impl_jacobian(matrixOut_t jacobian, vectorIn_t arg) const {
+    value_type t = arg[0];
+    jacobian(0,0) = -sin(t);
+    jacobian(1,0) =  cos(t);
+  }
+  value_type t0_;
+}; // class Rhs
+
+BOOST_AUTO_TEST_CASE(path_extraction_3) {
+  // Build planar robot with 2 prismatic joints.
+  DevicePtr_t robot(Device::create("xy"));
+  const std::string urdfString(
+      "<robot name=\"robot\">\n"
+      "  <link name=\"base_link\"/>\n"
+      "  <link name=\"lx\"/>\n"
+      "  <link name=\"ly\"/>\n"
+      "  <joint name=\"px\" type=\"prismatic\">\n"
+      "    <limit effort=\"1.0\" lower=\"-2.0\" upper=\"2.0\" velocity=\"2.0\"/>\n"
+      "    <axis xyz=\"1 0 0\"/>\n"
+      "    <parent link=\"base_link\"/>\n"
+      "    <child link=\"lx\"/>\n"
+      "  </joint>\n"
+      "  <joint name=\"py\" type=\"prismatic\">\n"
+      "    <limit effort=\"1.0\" lower=\"-2.0\" upper=\"2.0\" velocity=\"2.0\"/>\n"
+      "    <axis xyz=\"0 1 0\"/>"
+      "    <parent link=\"lx\"/>\n"
+      "    <child link=\"ly\"/>\n"
+      "  </joint>\n"
+      "</robot>");
+
+  hpp::pinocchio::urdf::loadModelFromString(robot, 0, "robot", "anchor", urdfString, "");
+  vector2_t q0; q0 << 1, 0;
+  vector2_t q1; q1 << 0, 1;
+  vector2_t q2; q2 << -1, 0;
+  vector2_t q3; q3 << 0, -1;
+  ConstraintSetPtr_t cs0(ConstraintSet::create(robot, "cs0"));
+  ConstraintSetPtr_t cs1(ConstraintSet::create(robot, "cs1"));
+  ConstraintSetPtr_t cs2(ConstraintSet::create(robot, "cs2"));
+  ConstraintSetPtr_t cs3(ConstraintSet::create(robot, "cs3"));
+  value_type threshold = 1e-4;
+  ConfigProjectorPtr_t cp0(ConfigProjector::create(robot, "cp0", threshold, 50));
+  ConfigProjectorPtr_t cp1(ConfigProjector::create(robot, "cp1", threshold, 50));
+  ConfigProjectorPtr_t cp2(ConfigProjector::create(robot, "cp2", threshold, 50));
+  ConfigProjectorPtr_t cp3(ConfigProjector::create(robot, "cp3", threshold, 50));
+  cs0->addConstraint(cp0);
+  cs1->addConstraint(cp1);
+  cs2->addConstraint(cp2);
+  cs3->addConstraint(cp3);
+  /* Constraint with non constant right hand side
+            / cos t \
+        q = |       |
+            \ sin t /
+  */
+  ImplicitPtr_t f0(
+      Implicit::create(Identity::create(LiegroupSpace::R2(), "I2"),
+          ComparisonTypes_t(2, hpp::constraints::Equality)));
+  f0->rightHandSideFunction(Rhs::create(0));
+  cp0->add(f0);
+  ImplicitPtr_t f1(
+      Implicit::create(Identity::create(LiegroupSpace::R2(), "I2"),
+          ComparisonTypes_t(2, hpp::constraints::Equality)));
+  f1->rightHandSideFunction(Rhs::create(M_PI/2));
+  cp1->add(f1);
+  ImplicitPtr_t f2(
+      Implicit::create(Identity::create(LiegroupSpace::R2(), "I2"),
+          ComparisonTypes_t(2, hpp::constraints::Equality)));
+  f2->rightHandSideFunction(Rhs::create(M_PI));
+  cp2->add(f2);
+  ImplicitPtr_t f3(
+      Implicit::create(Identity::create(LiegroupSpace::R2(), "I2"),
+          ComparisonTypes_t(2, hpp::constraints::Equality)));
+  f3->rightHandSideFunction(Rhs::create(3*M_PI/2));
+  cp3->add(f3);
+
+  // Create a constrained paths between qi and q{i+1}
+  PathPtr_t p0(LocalPath::create(std::make_pair(0, M_PI/2), q0, q1, cs0));
+  PathPtr_t p1(LocalPath::create(std::make_pair(0, M_PI/2), q1, q2, cs1));
+  PathPtr_t p2(LocalPath::create(std::make_pair(0, M_PI/2), q2, q3, cs2));
+  PathPtr_t p3(LocalPath::create(std::make_pair(0, M_PI/2), q3, q0, cs3));
+  // Convert them into interpolated paths
+  PathPtr_t ip0(InterpolatedPath::create(p0, robot, 4));
+  PathPtr_t ip1(InterpolatedPath::create(p1, robot, 4));
+  PathPtr_t ip2(InterpolatedPath::create(p2, robot, 4));
+  PathPtr_t ip3(InterpolatedPath::create(p3, robot, 4));
+  // Concatenate them in a path vector
+  PathVectorPtr_t pv(PathVector::create(2, 2));
+  pv->appendPath(ip0);
+  pv->appendPath(ip1);
+  pv->appendPath(ip2);
+  pv->appendPath(ip3);
+  PathPtr_t ep0(pv->extract(M_PI/4, 5*M_PI/4));
+   PathPtr_t ep1(ep0->reverse());
+  BOOST_CHECK_CLOSE(ep0->length(), M_PI,
+                    std::numeric_limits<float>::epsilon());
+  BOOST_CHECK_CLOSE(ep1->length(), M_PI,
+                    std::numeric_limits<float>::epsilon());
+  for (size_type i=0; i<=50; ++i) {
+    bool success;
+    value_type s = ((value_type)i)*M_PI/50;
+    Configuration_t q = ep0->eval(s, success);
+    assert(success);
+    BOOST_CHECK(fabs(q[0] - cos(M_PI/4 + s)) <= threshold);
+    BOOST_CHECK(fabs(q[1] - sin(M_PI/4 + s)) <= threshold);
+    q = ep1->eval(s, success);
+    assert(success);
+    BOOST_CHECK(fabs(q[0] - cos(5*M_PI/4 - s)) <= threshold);
+    BOOST_CHECK(fabs(q[1] - sin(5*M_PI/4 - s)) <= threshold);
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
When copying a path, copy the constraints so that extracting a sub-path will not spoil the initial path.
Add a test on path extraction.
Requires https://github.com/humanoid-path-planner/hpp-constraints/pull/252.