### PR TITLE
[Spline] Remove assert on second derivative.

### DIFF
--- a/include/hpp/core/path/spline.hh
+++ b/include/hpp/core/path/spline.hh
@@ -321,7 +321,8 @@ class HPP_CORE_DLLAPI Spline : public Path {
 
   /// Compute the derivative of required order of the spline
   ///
-  /// \warning If the output space of the spline is not a vector space, derivatives of order
+  /// \warning If the output space of the spline is not a vector space,
+  /// derivatives of order
   ///          greater than 1 on the non-vertor space parts are wrong.
   void impl_derivative(vectorOut_t res, const value_type& t,
                        size_type order) const;

--- a/include/hpp/core/path/spline.hh
+++ b/include/hpp/core/path/spline.hh
@@ -319,6 +319,10 @@ class HPP_CORE_DLLAPI Spline : public Path {
 
   bool impl_compute(ConfigurationOut_t configuration, value_type t) const;
 
+  /// Compute the derivative of required order of the spline
+  ///
+  /// \warning If the output space of the spline is not a vector space, derivatives of order
+  ///          greater than 1 on the non-vertor space parts are wrong.
   void impl_derivative(vectorOut_t res, const value_type& t,
                        size_type order) const;
 

--- a/src/path/spline.cc
+++ b/src/path/spline.cc
@@ -371,6 +371,8 @@ bool Spline<_SplineType, _Order>::impl_compute(ConfigurationOut_t res,
   return true;
 }
 
+// For splines on configuration space that are not vector space, the second derivative is not
+// correct on the non-vector space parts.
 template <int _SplineType, int _Order>
 void Spline<_SplineType, _Order>::impl_derivative(vectorOut_t res,
                                                   const value_type& s,
@@ -379,14 +381,13 @@ void Spline<_SplineType, _Order>::impl_derivative(vectorOut_t res,
   assert(order > 0);
   // For non vector space, it is not possible to compute the derivatives
   // at a higher order. At the d2+/dv2 is not available for SE(n) and SO(n).
-  assert(order == 1 || robot_->configSpace()->isVectorSpace());
   BasisFunctionVector_t basisFunc;
   const value_type u =
       (length() == 0 ? 0 : (s - paramRange().first) / paramLength());
   basisFunctionDerivative(order, u, basisFunc);
   res.noalias() = parameters_.transpose() * basisFunc;
 
-  if (!robot_->configSpace()->isVectorSpace()) {
+  if (!robot_->configSpace()->isVectorSpace() && order == 1) {
     basisFunctionDerivative(0, u, basisFunc);
     vector_t v(parameters_.transpose() * basisFunc);
     // true means: res <- Jdiff * res

--- a/src/path/spline.cc
+++ b/src/path/spline.cc
@@ -371,8 +371,8 @@ bool Spline<_SplineType, _Order>::impl_compute(ConfigurationOut_t res,
   return true;
 }
 
-// For splines on configuration space that are not vector space, the second derivative is not
-// correct on the non-vector space parts.
+// For splines on configuration space that are not vector space, the second
+// derivative is not correct on the non-vector space parts.
 template <int _SplineType, int _Order>
 void Spline<_SplineType, _Order>::impl_derivative(vectorOut_t res,
                                                   const value_type& s,


### PR DESCRIPTION
  The second derivative on configuration spaces that include Lie groups like
  SE(3) is not computed. In some cases, this derivative is not useful and it
  still make sense to call the method with order 2, getting a partially wrong
  result. It is up to the user not to use the wrong part.