### PR TITLE
Bound two previously-unbounded loops in planning/validation by wall-clock timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ set(${PROJECT_NAME}_HEADERS
 
 set(${PROJECT_NAME}_SOURCES
     src/astar.hh
+    src/astar.cc
     src/bi-rrt-planner.cc
     src/collision-validation.cc
     src/configuration-shooter/uniform.cc

--- a/include/hpp/core/continuous-validation/progressive.hh
+++ b/include/hpp/core/continuous-validation/progressive.hh
@@ -60,6 +60,11 @@ class HPP_CORE_DLLAPI Progressive : public ContinuousValidation {
                                  const value_type& tolerance);
   virtual ~Progressive();
 
+  /// Get wall-clock timeout (seconds) for validateStraightPath
+  value_type timeOut() const { return timeOut_; }
+  /// Set wall-clock timeout (seconds) for validateStraightPath
+  void timeOut(const value_type& timeOut) { timeOut_ = timeOut; }
+
  protected:
   /// Constructor
   /// \param robot the robot for which continuous validation is performed,
@@ -71,6 +76,8 @@ class HPP_CORE_DLLAPI Progressive : public ContinuousValidation {
  private:
   // Weak pointer to itself
   ProgressiveWkPtr_t weak_;
+  // Wall-clock timeout (seconds) for validateStraightPath, see timeOut()
+  value_type timeOut_;
   bool validateStraightPath(IntervalValidations_t& bodyPairCollisions,
                             const PathPtr_t& path, bool reverse,
                             PathPtr_t& validPart,

--- a/src/astar.cc
+++ b/src/astar.cc
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2014 CNRS
+// Authors: Florent Lamiraux
+//
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+
+#include "astar.hh"
+
+namespace hpp {
+namespace core {
+HPP_START_PARAMETER_DECLARATION(Astar)
+Problem::declareParameter(ParameterDescription(
+    Parameter::FLOAT, "Astar/timeOut",
+    "Duration in seconds above which Astar::findPath will stop trying to "
+    "extract the solution path from the roadmap.",
+    Parameter(30.0)));
+HPP_END_PARAMETER_DECLARATION(Astar)
+}  // namespace core
+}  // namespace hpp

--- a/src/astar.hh
+++ b/src/astar.hh
@@ -38,6 +38,8 @@
 #include <hpp/core/node.hh>
 #include <hpp/core/path-vector.hh>
 #include <hpp/core/path/cost.hh>
+#include <hpp/core/problem.hh>
+#include <hpp/core/roadmap.hh>
 #include <hpp/util/debug.hh>
 #include <limits>
 
@@ -54,10 +56,13 @@ class HPP_CORE_LOCAL Astar {
   Parent_t parent_;
   RoadmapPtr_t roadmap_;
   DistancePtr_t distance_;
+  double timeOut_;
 
  public:
-  Astar(const RoadmapPtr_t& roadmap, const DistancePtr_t distance)
-      : roadmap_(roadmap), distance_(distance) {}
+  Astar(const RoadmapPtr_t& roadmap, const ProblemConstPtr_t& problem)
+      : roadmap_(roadmap),
+        distance_(problem->distance()),
+        timeOut_(problem->getParameter("Astar/timeOut").floatValue()) {}
 
   void solution(PathVectorPtr_t sol) {
     NodePtr_t node = findPath();
@@ -110,14 +115,13 @@ class HPP_CORE_LOCAL Astar {
     // wall-clock bound; pathological roadmaps (open_/closed_ are
     // std::list, O(n) membership checks) could run indefinitely.
     bpt::ptime astarStart(bpt::microsec_clock::universal_time());
-    const double astarTimeOutSeconds = 30.0;
     open_.push_back(roadmap_->initNode());
     while (!open_.empty()) {
       bpt::ptime astarNow(bpt::microsec_clock::universal_time());
       double astarElapsed =
           static_cast<double>((astarNow - astarStart).total_milliseconds()) /
           1000.0;
-      if (astarElapsed > astarTimeOutSeconds) {
+      if (astarElapsed > timeOut_) {
         hppDout(error, "Astar::findPath timed out after "
                            << astarElapsed << "s, open=" << open_.size()
                            << " closed=" << closed_.size());

--- a/src/astar.hh
+++ b/src/astar.hh
@@ -30,6 +30,7 @@
 #ifndef HPP_CORE_ASTAR_HH
 #define HPP_CORE_ASTAR_HH
 
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include <hpp/core/config.hh>
 #include <hpp/core/distance.hh>
 #include <hpp/core/edge.hh>
@@ -37,6 +38,7 @@
 #include <hpp/core/node.hh>
 #include <hpp/core/path-vector.hh>
 #include <hpp/core/path/cost.hh>
+#include <hpp/util/debug.hh>
 #include <limits>
 
 namespace hpp {
@@ -97,14 +99,31 @@ class HPP_CORE_LOCAL Astar {
   }
 
   NodePtr_t findPath() {
+    namespace bpt = boost::posix_time;
     closed_.clear();
     open_.clear();
     parent_.clear();
     estimatedCostToGoal_.clear();
     costFromStart_.clear();
 
+    // Unlike PathPlanner::solve(), this search had no iteration cap or
+    // wall-clock bound; pathological roadmaps (open_/closed_ are
+    // std::list, O(n) membership checks) could run indefinitely.
+    bpt::ptime astarStart(bpt::microsec_clock::universal_time());
+    const double astarTimeOutSeconds = 30.0;
     open_.push_back(roadmap_->initNode());
     while (!open_.empty()) {
+      bpt::ptime astarNow(bpt::microsec_clock::universal_time());
+      double astarElapsed =
+          static_cast<double>((astarNow - astarStart).total_milliseconds()) /
+          1000.0;
+      if (astarElapsed > astarTimeOutSeconds) {
+        hppDout(error, "Astar::findPath timed out after "
+                           << astarElapsed << "s, open=" << open_.size()
+                           << " closed=" << closed_.size());
+        throw std::runtime_error(
+            "A* timed out extracting the solution path from the roadmap.");
+      }
       open_.sort(SortFunctor(estimatedCostToGoal_));
       Nodes_t::iterator itv = open_.begin();
       NodePtr_t current(*itv);

--- a/src/continuous-validation/progressive.cc
+++ b/src/continuous-validation/progressive.cc
@@ -27,6 +27,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 // DAMAGE.
 
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include <hpp/core/collision-path-validation-report.hh>
 #include <hpp/core/continuous-validation/progressive.hh>
 #include <hpp/core/path-vector.hh>
@@ -98,7 +99,35 @@ bool Progressive::validateStraightPath(
   // If the interval is of length 0, there is only one configuration to
   // validate.
   if (reverse ? t <= tmin : t >= tmax) finished++;
+  // The advancement step derives from the nearest collision pair's
+  // separation and can shrink toward zero near-tangent to an obstacle,
+  // making the iteration count to cover [tmin, tmax] unbounded in
+  // practice. Bound by wall-clock (checked every 1000 steps to keep the
+  // check itself cheap) rather than by iteration count, since per-step
+  // cost is exactly what varies here.
+  namespace bpt = boost::posix_time;
+  bpt::ptime progStart(bpt::microsec_clock::universal_time());
+  const double progTimeOutSeconds = 15.0;
+  unsigned long int nStep = 0;
   while (finished < 2 && valid) {
+    ++nStep;
+    if (nStep % 1000 == 0) {
+      bpt::ptime progNow(bpt::microsec_clock::universal_time());
+      double progElapsed =
+          static_cast<double>(
+              (progNow - progStart).total_milliseconds()) /
+          1000.0;
+      if (progElapsed > progTimeOutSeconds) {
+        hppDout(error, "Progressive::validateStraightPath timed out after "
+                            << nStep << " steps / " << progElapsed
+                            << "s without covering [" << tmin << ", " << tmax
+                            << "] (stuck near t=" << t << ")");
+        report = PathValidationReportPtr_t(new PathValidationReport(
+            t, ValidationReportPtr_t(new ProjectionError())));
+        valid = false;
+        break;
+      }
+    }
     bool success = path->eval(q, t);
     value_type tprev = t;
     if (!success) {

--- a/src/continuous-validation/progressive.cc
+++ b/src/continuous-validation/progressive.cc
@@ -107,7 +107,6 @@ bool Progressive::validateStraightPath(
   // cost is exactly what varies here.
   namespace bpt = boost::posix_time;
   bpt::ptime progStart(bpt::microsec_clock::universal_time());
-  const double progTimeOutSeconds = 15.0;
   unsigned long int nStep = 0;
   while (finished < 2 && valid) {
     ++nStep;
@@ -116,7 +115,7 @@ bool Progressive::validateStraightPath(
       double progElapsed =
           static_cast<double>((progNow - progStart).total_milliseconds()) /
           1000.0;
-      if (progElapsed > progTimeOutSeconds) {
+      if (progElapsed > timeOut_) {
         hppDout(error, "Progressive::validateStraightPath timed out after "
                            << nStep << " steps / " << progElapsed
                            << "s without covering [" << tmin << ", " << tmax
@@ -164,7 +163,7 @@ void Progressive::init(const ProgressiveWkPtr_t weak) {
 }
 
 Progressive::Progressive(const DevicePtr_t& robot, const value_type& tolerance)
-    : ContinuousValidation(robot, tolerance), weak_() {
+    : ContinuousValidation(robot, tolerance), weak_(), timeOut_(15.0) {
   if (tolerance <= 0) {
     throw std::runtime_error(
         "tolerance should be positive for"

--- a/src/continuous-validation/progressive.cc
+++ b/src/continuous-validation/progressive.cc
@@ -114,14 +114,13 @@ bool Progressive::validateStraightPath(
     if (nStep % 1000 == 0) {
       bpt::ptime progNow(bpt::microsec_clock::universal_time());
       double progElapsed =
-          static_cast<double>(
-              (progNow - progStart).total_milliseconds()) /
+          static_cast<double>((progNow - progStart).total_milliseconds()) /
           1000.0;
       if (progElapsed > progTimeOutSeconds) {
         hppDout(error, "Progressive::validateStraightPath timed out after "
-                            << nStep << " steps / " << progElapsed
-                            << "s without covering [" << tmin << ", " << tmax
-                            << "] (stuck near t=" << t << ")");
+                           << nStep << " steps / " << progElapsed
+                           << "s without covering [" << tmin << ", " << tmax
+                           << "] (stuck near t=" << t << ")");
         report = PathValidationReportPtr_t(new PathValidationReport(
             t, ValidationReportPtr_t(new ProjectionError())));
         valid = false;

--- a/src/problem-target/goal-configurations.cc
+++ b/src/problem-target/goal-configurations.cc
@@ -67,7 +67,7 @@ PathVectorPtr_t GoalConfigurations::computePath(
     const RoadmapPtr_t& roadmap) const {
   ProblemPtr_t problem(problem_.lock());
   assert(problem);
-  Astar astar(roadmap, problem->distance());
+  Astar astar(roadmap, problem);
   PathVectorPtr_t sol = PathVector::create(problem->robot()->configSize(),
                                            problem->robot()->numberDof());
   astar.solution(sol);

--- a/src/problem-target/task-target.cc
+++ b/src/problem-target/task-target.cc
@@ -81,7 +81,7 @@ NumericalConstraints_t TaskTarget::constraints() const {
 PathVectorPtr_t TaskTarget::computePath(const RoadmapPtr_t& roadmap) const {
   ProblemPtr_t problem(problem_.lock());
   assert(problem);
-  Astar astar(roadmap, problem->distance());
+  Astar astar(roadmap, problem);
   PathVectorPtr_t sol = PathVector::create(problem->robot()->configSize(),
                                            problem->robot()->numberDof());
   astar.solution(sol);
@@ -90,6 +90,9 @@ PathVectorPtr_t TaskTarget::computePath(const RoadmapPtr_t& roadmap) const {
     Configuration_t q(roadmap->initNode()->configuration());
     sol->appendPath((*problem->steeringMethod())(q, q));
   }
+  // Only reached on success: if astar.solution() throws (e.g. Astar/timeOut),
+  // the temporary goal nodes added by reached() are deliberately left in the
+  // roadmap rather than reset here.
   roadmap->resetGoalNodes();  // remove the temporary goal node
   return sol;
 }


### PR DESCRIPTION
## Summary
Running long multi-phase manipulation sequences with many simultaneous
grasps, we hit indefinite hangs (30-45+ min, no error, no output) at two
independent places with no timeout at all, unlike sibling code in the
same files:

- `Astar::findPath()` (src/astar.hh) — the roadmap-to-path extraction
  search used by `GoalConfigurations::computePath()` whenever a direct
  connection is found immediately (skipping the RRT's own bounded main
  loop entirely).
- `Progressive::validateStraightPath()`
  (src/continuous-validation/progressive.cc) — the shared continuous
  path-validation routine, whose adaptive step size can shrink toward
  zero near a tangential collision pair, making the true iteration
  count needed unbounded in practice.

Both are now bounded by wall-clock time (30s / 15s respectively),
matching the existing pattern in `PathPlanner::solve()`
(`maxIterations_`/`timeOut_`), and fail cleanly instead of hanging —
callers already treat both outcomes as retriable.

## Testing
- Reproduced both hangs via targeted tracing bracketing each step of
  the planning pipeline, isolating each call site independently.
- Rebuilt and verified no regressions in a full downstream 13-phase
  sequential manipulation test suite, which previously could not get
  past an early phase and now completes end-to-end.
- Compile-verified locally; CI (nix build / ci_ros2) should be run on
  the PR itself.
